### PR TITLE
Introducing threes as wildcards

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -44,7 +44,7 @@ object Main extends App {
 //  var AI = player.Player("AI", game.GameUtilities.dealNewHand(numberOfPlayers, totalNormalCards))
 //  var computer = player.Player("Computer", game.GameUtilities.dealNewHand(numberOfPlayers, totalNormalCards))
 
-  val listOfNames = List("Player1", "Player2", "Player3", "Player4", "Player5", "Player6", "Player7", "Player8")
+  val listOfNames = List("Player1", "Player2", "Player3")
   val listOfNames2 = List("Player1", "Player2")
   // Comment out seed for true randomness
 //  val listOfPlayers = game.GameUtilities.generatePlayersAndDealHands(listOfNames, seed=5).toBuffer

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -48,7 +48,8 @@ object Main extends App {
   // Comment out seed for true randomness
 //  val listOfPlayers = game.GameUtilities.generatePlayersAndDealHands(listOfNames, seed=5).toBuffer
   // 77 and 13 are good seeds
-  val listOfPlayers = GameUtilities.generatePlayersAndDealHands(listOfNames, seed=13).toBuffer
+//  val listOfPlayers = GameUtilities.generatePlayersAndDealHands(listOfNames, seed=13).toBuffer
+  val listOfPlayers = GameUtilities.generatePlayersAndDealHands(listOfNames).toBuffer
   val listOfPlayers2 = GameUtilities.generatePlayersAndDealHands(listOfNames2, seed=77).toBuffer
 
   val game = Game(Move(List.empty))

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,6 +1,7 @@
 import game.FaceValue._
 import game.Suits._
-import game.{Game, GameUtilities, Hand, Joker, Move, NormalCard, SpecialCard}
+import game.{Game, GameUtilities, Hand, Joker, Move, NormalCard, SpecialCard, WildCard}
+import player.Player
 
 object Main extends App {
 
@@ -43,7 +44,7 @@ object Main extends App {
 //  var AI = player.Player("AI", game.GameUtilities.dealNewHand(numberOfPlayers, totalNormalCards))
 //  var computer = player.Player("Computer", game.GameUtilities.dealNewHand(numberOfPlayers, totalNormalCards))
 
-  val listOfNames = List("Player1", "Player2", "Player3", "Player4")
+  val listOfNames = List("Player1", "Player2", "Player3", "Player4", "Player5", "Player6", "Player7", "Player8")
   val listOfNames2 = List("Player1", "Player2")
   // Comment out seed for true randomness
 //  val listOfPlayers = game.GameUtilities.generatePlayersAndDealHands(listOfNames, seed=5).toBuffer
@@ -57,8 +58,19 @@ object Main extends App {
 
   println("The starting state is : " + game.startState)
   println("\n")
-//  game.play(listOfPlayers)
   game.play(listOfPlayers)
+//  game.play(listOfPlayers)
+
+//  val hand4 = Hand(List(NormalCard(ACE, Spade)))
+//  val hand1 = Hand(List(WildCard(THREE, Diamond)))
+//  val hand2 = Hand(List(SpecialCard(TWO, Club)))
+//  val hand3 = Hand(List(NormalCard(KING, Spade)))
+//
+//  val testCasePlayers = List("P4", "P1", "P2", "P3")
+//  val lop = List(Player("P4", hand4), Player("P1", hand1),
+//    Player("P2", hand2), Player("P3", hand3) )
+//
+//  game.play(lop.toBuffer)
 
 }
 

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -44,7 +44,7 @@ object Main extends App {
 //  var AI = player.Player("AI", game.GameUtilities.dealNewHand(numberOfPlayers, totalNormalCards))
 //  var computer = player.Player("Computer", game.GameUtilities.dealNewHand(numberOfPlayers, totalNormalCards))
 
-  val listOfNames = List("Player1", "Player2", "Player3")
+  val listOfNames = List("Player1", "Player2", "Player3", "Player4")
   val listOfNames2 = List("Player1", "Player2")
   // Comment out seed for true randomness
 //  val listOfPlayers = game.GameUtilities.generatePlayersAndDealHands(listOfNames, seed=5).toBuffer

--- a/src/main/scala/game/Game.scala
+++ b/src/main/scala/game/Game.scala
@@ -20,6 +20,8 @@ case class Game(startState: Move) {
 
     var currentState = this.startState
 
+    Round.initialListOfPlayerNames = listOfPlayers.map(p => p.name).toList
+
     var round = Round(currentState, "", listOfPlayers.size, 0,
       listOfPlayers.toList, Round.getNoPassList(listOfPlayers.size))
 
@@ -39,7 +41,9 @@ case class Game(startState: Move) {
         val nextPlayerIndex =  try {
           round.getIndexOf(round.lastMovePlayedBy)
         } catch {
-          case e: Exception => round.currentPlayerTurn
+          // If last move is played by someone who doesnt exist anymore
+          // Then next person to play is the one player in starting order
+          case e: Exception => round.getIndexOfNextPlayer
         }
 
         // Update round with index of next player
@@ -92,7 +96,8 @@ case class Game(startState: Move) {
       if(listOfPlayers(round.currentPlayerTurn).status == Complete) {
         println(listOfPlayers(round.currentPlayerTurn).name + " has finished!\n")
         listOfPlayers.remove(round.currentPlayerTurn)
-        round = Round(currentState, round.lastMovePlayedBy, listOfPlayers.size, round.currentPlayerTurn - 1, listOfPlayers.toList, round.roundPassStatus)
+        round = Round(currentState, round.lastMovePlayedBy, listOfPlayers.size, round.currentPlayerTurn - 1,
+          listOfPlayers.toList, round.updatedRoundPassStatus(round.currentPlayerTurn))
         playerCompletionOrder += currentPlayerObject.name
       }
 

--- a/src/main/scala/game/Game.scala
+++ b/src/main/scala/game/Game.scala
@@ -85,7 +85,7 @@ case class Game(startState: Move) {
       println("The current round state is : " + round.gameState)
       //    println("The pass status is : " + round.roundPassStatus)
 
-      val newHandAfterPlaying = currentPlayerObject.getNewHand(currentPlayerObject.hand, nextMove)
+      val newHandAfterPlaying = GameUtilities.getNewHand(currentPlayerObject.hand, nextMove)
       listOfPlayers.update(round.currentPlayerTurn, Player(currentPlayerObject.name, newHandAfterPlaying))
 
       // Check if playing last move led player to complete

--- a/src/main/scala/game/Game.scala
+++ b/src/main/scala/game/Game.scala
@@ -110,7 +110,7 @@ case class Game(startState: Move) {
       }
 
       println("------------------------\n")
-//            Thread.sleep(10)
+//            Thread.sleep(100)
     }
 
     printStats()

--- a/src/main/scala/game/GameEngine.scala
+++ b/src/main/scala/game/GameEngine.scala
@@ -1,5 +1,7 @@
 package game
 
+import game.FaceValue.THREE
+import game.Suits.Diamond
 import player.PlayerIndicators
 import utils.Consants
 
@@ -14,8 +16,8 @@ case object GameEngine {
                                  playerIndicators: PlayerIndicators = PlayerIndicators(Hand(List.empty))): Double = {
     validMove.cards match {
       case List(NormalCard(_,_), _*) | List(WildCard(_,_,_), _*) =>
-        if(gameState.isEmpty)  scala.math.max(0, applyNormalCardHeuristicWithMoveSizeModifier(validMove) - wildCardUsagePenalty(validMove))
-        else scala.math.max(0, applyNormalCardHeuristicWithPenaltyForBreakingSets(validMove, gameState,
+        if(gameState.isEmpty)  scala.math.max(0d, applyNormalCardHeuristicWithMoveSizeModifier(validMove) - wildCardUsagePenalty(validMove))
+        else scala.math.max(0d, applyNormalCardHeuristicWithPenaltyForBreakingSets(validMove, gameState,
               playerIndicators.getListSetSizeForCard(validMove)) - wildCardUsagePenalty(validMove))
       case _ => throw IllegalHeuristicFunctionException("Incorrect heuristic supplied to evaluate special card")
     }
@@ -70,10 +72,16 @@ case object GameEngine {
 
   /*
   Penalizes the usage of WildCards. Subtracted from heuristic value obtained based on move
+  Greatly Favours higher assumedValue
+  Slightly Favours higher parity
+  Does not favour multiple 3s
    */
   def wildCardUsagePenalty(validMove: Move): Double = {
     if(validMove.cards.forall(card => card match {case n: NormalCard => true; case _ => false})) 0
-    else 0
+    else
+      ((0.25 * (1/(validMove.moveFaceValue - WildCard(THREE, Diamond).intValue)))
+         + (0.03 * validMove.parity)
+         + (0.17 * 1 / GameUtilities.getNumberOfWildCardsInMove(validMove)))
   }
 
   /*
@@ -81,7 +89,7 @@ case object GameEngine {
   Assumes validMove comprises only of NormalCards
    */
   def applyNormalCardHeuristicWithMoveSizeModifier(validMove: Move): Double = {
-    (0.78d * (1d/validMove.moveFaceValue) + (0.22d * validMove.parity/Consants.maxMoveSize))
+    (0.78d * (1d/(validMove.moveFaceValue - WildCard(THREE, Diamond).intValue)) + (0.22d * validMove.parity/Consants.maxMoveSize))
   }
 
   /*
@@ -89,7 +97,7 @@ case object GameEngine {
    */
   def applyNormalCardHeuristicWithPenaltyForBreakingSets(validMove: Move, gameState: Move, maxCards: Int): Double = {
     ((0.22d * (1d/(validMove.moveFaceValue - gameState.moveFaceValue)))
-      + (0.78d * 1/(maxCards - validMove.parity + 1)))
+      + (0.78d * 1/(maxCards - validMove.numberOfNormalcards + 1)))
   }
 
   /*
@@ -113,6 +121,7 @@ case object GameEngine {
     1.1 Even then, there isnt a guarantee that the special card will be chosen
    */
   def getNextMove(validMoves: Moves, gameState: Move)(heuristic: (Move, Move, PlayerIndicators) => Double, playerIndicators: PlayerIndicators): Option[Move] = {
+    if(validMoves.moves.size == 1) return Some(validMoves.moves.head)
     try {
       Some(
         validMoves.moves(validMoves.moves
@@ -122,7 +131,9 @@ case object GameEngine {
           .maxBy(_._1)
           ._2))
     } catch {
-      case _: Exception => None
+      case e: Exception =>
+//        e.printStackTrace()
+        None
     }
   }
 

--- a/src/main/scala/game/GameEngine.scala
+++ b/src/main/scala/game/GameEngine.scala
@@ -88,9 +88,9 @@ case object GameEngine {
     if(validMove.cards.forall(card => card match {case n: NormalCard => true; case _ => false})) 0
     else
       wildCardPenaltyModifier *
-        ((0.4 * (1/(validMove.moveFaceValue - WildCard(THREE, Diamond).intValue)))
-         + (0.2 * validMove.parity)
-         + (0.3 * 1 / GameUtilities.getNumberOfWildCardsInMove(validMove)))
+        ((0.35 * (1/(validMove.moveFaceValue - WildCard(THREE, Diamond).intValue)))
+         + (0.2 * (1/validMove.parity))
+         + (0.45 * 1 / (Consants.maxMoveSize - GameUtilities.getNumberOfWildCardsInMove(validMove))))
   }
 
   /*
@@ -99,7 +99,7 @@ case object GameEngine {
   Using base as 3-intValue here because it is the lowest possible to play
    */
   def applyNormalCardHeuristicWithMoveSizeModifier(validMove: Move): Double = {
-    (0.78d * (1d/(validMove.moveFaceValue - WildCard(THREE, Diamond).intValue)) + (0.22d * validMove.parity/Consants.maxMoveSize))
+    (0.78d * (1d/(validMove.moveFaceValue)) + (0.22d * validMove.parity/Consants.maxMoveSize))
   }
 
   /*

--- a/src/main/scala/game/GameEngine.scala
+++ b/src/main/scala/game/GameEngine.scala
@@ -87,26 +87,26 @@ case object GameEngine {
   def wildCardUsagePenalty(validMove: Move, wildCardPenaltyModifier: Double): Double = {
     if(validMove.cards.forall(card => card match {case n: NormalCard => true; case _ => false})) 0
     else {
-      val d1 = 1 - applyCardFaceValueStepFunction(validMove.moveFaceValue)
-      val d2 =  1 - (validMove.parity/(Consants.maxMoveSize + 1))
-      val d3 = Consants.maxMoveSize - GameUtilities.getNumberOfWildCardsInMove(validMove) + 1
+      val d1: Double = 1 - applyCardFaceValueStepFunction(validMove.moveFaceValue)
+      val d2: Double =  1 - ((validMove.parity * 1.0d)/(Consants.maxMoveSize + 1))
+      val d3: Double = Consants.maxMoveSize - GameUtilities.getNumberOfWildCardsInMove(validMove) + 1
       wildCardPenaltyModifier *
-          ((0.5 * d1)
-         + (0.4 * d2)
-         + (0.3 * 1/d3))
+          ((0.5d * d1)
+         + (0.4d * d2)
+         + (0.3d * 1/d3))
     }
   }
 
   /*
-Divides 0.0-1.0 into 11 equal intervals, each interval corresponds to a card (4,5,...K,A)
-Returns the interval the faceValue of the card falls under
-Example :- faceValue = 4, Returns --> [1 * (1/11)]
-Example :- faceValue = 14, Returns -> [11 * (1/11)]
-Assumes faceValue is between 4 and 11
+  Divides 0.0-1.0 into 11 equal intervals, each interval corresponds to a card (4,5,...K,A)
+  Returns the interval the faceValue of the card falls under
+  Example :- faceValue = 4, Returns --> [1 * (1/11)]
+  Example :- faceValue = 14, Returns -> [11 * (1/11)]
+  Assumes faceValue is between 4 and 11
  */
   def applyCardFaceValueStepFunction(faceValue: Int): Double = {
     if(faceValue < 4 || faceValue > 14) throw IllegalFaceValueException("FaceValue must be between FOUR(4) and ACE(14)")
-    else (faceValue - 3) * (1/11)
+    else (faceValue - 3) * (1d/11d)
   }
 
 

--- a/src/main/scala/game/GameEngine.scala
+++ b/src/main/scala/game/GameEngine.scala
@@ -119,10 +119,10 @@ case object GameEngine {
 
   // TODO - It was noticed during testing that A,A was favored over a single 8, when the hand was 8, Q, A, A - this isnt the most desirable
   def getNextMoveWrapper(validMoves: Moves, gameState: Move)(implicit playerIndicators: PlayerIndicators): Option[Move] = {
-    // If normal moves are available, play them first!
+    // If normal (non-special, including 3s) moves are available, play them first!
     if(!GameUtilities.isOnlySpecialMovesAvailable(validMoves)) {
-      val filteredValidMoves = GameUtilities.filterNonSpecialCardMoves(validMoves)
-      getNextMove(filteredValidMoves, gameState)(getNormalCardMoveHeuristic, playerIndicators)
+      val filteredNonSpecialValidMoves = GameUtilities.filterNonSpecialCardMoves(validMoves)
+      getNextMove(filteredNonSpecialValidMoves, gameState)(getNormalCardMoveHeuristic, playerIndicators)
     } else {
       // If comprising ONLY of special moves, do nothing
       getNextMove(validMoves, gameState)(getSpecialCardMoveHeuristic, playerIndicators)

--- a/src/main/scala/game/GameEngine.scala
+++ b/src/main/scala/game/GameEngine.scala
@@ -116,7 +116,7 @@ Assumes faceValue is between 4 and 11
   Using base as 3-intValue here because it is the lowest possible to play
    */
   def applyNormalCardHeuristicWithMoveSizeModifier(validMove: Move): Double = {
-    (0.78d * (1d/(validMove.moveFaceValue)) + (0.22d * validMove.parity/Consants.maxMoveSize))
+    (0.8d * (1d/(validMove.moveFaceValue)) + (0.2d * validMove.parity/Consants.maxMoveSize))
   }
 
   /*

--- a/src/main/scala/game/GameEngine.scala
+++ b/src/main/scala/game/GameEngine.scala
@@ -16,9 +16,9 @@ case object GameEngine {
                                  playerIndicators: PlayerIndicators = PlayerIndicators(Hand(List.empty))): Double = {
     validMove.cards match {
       case List(NormalCard(_,_), _*) | List(WildCard(_,_,_), _*) =>
-        if(gameState.isEmpty)  scala.math.max(0d, applyNormalCardHeuristicWithMoveSizeModifier(validMove) - wildCardUsagePenalty(validMove))
+        if(gameState.isEmpty)  scala.math.max(0d, applyNormalCardHeuristicWithMoveSizeModifier(validMove) - wildCardUsagePenalty(validMove)/2)
         else scala.math.max(0d, applyNormalCardHeuristicWithPenaltyForBreakingSets(validMove, gameState,
-              playerIndicators.getListSetSizeForCard(validMove)) - wildCardUsagePenalty(validMove))
+              playerIndicators.getListSetSizeForCard(validMove)) - wildCardUsagePenalty(validMove)/2)
       case _ => throw IllegalHeuristicFunctionException("Incorrect heuristic supplied to evaluate special card")
     }
   }
@@ -122,10 +122,6 @@ case object GameEngine {
    */
   def getNextMove(validMoves: Moves, gameState: Move)(heuristic: (Move, Move, PlayerIndicators) => Double,
                                                       playerIndicators: PlayerIndicators): Option[Move] = {
-    /* If there is only one move left, and it is the only move available (not even valid), return it */
-    if(validMoves.moves.size == 1
-      && GameUtilities.getNewHand(playerIndicators.hand, Some(validMoves.moves.head)).listOfCards.isEmpty)
-      return Some(validMoves.moves.head)
     try {
       Some(
         validMoves.moves(validMoves.moves

--- a/src/main/scala/game/GameEngine.scala
+++ b/src/main/scala/game/GameEngine.scala
@@ -87,14 +87,16 @@ case object GameEngine {
   def wildCardUsagePenalty(validMove: Move, wildCardPenaltyModifier: Double): Double = {
     if(validMove.cards.forall(card => card match {case n: NormalCard => true; case _ => false})) 0
     else
-      wildCardPenaltyModifier *  ((0.25 * (1/(validMove.moveFaceValue - WildCard(THREE, Diamond).intValue)))
-         + (0.03 * validMove.parity)
-         + (0.17 * 1 / GameUtilities.getNumberOfWildCardsInMove(validMove)))
+      wildCardPenaltyModifier *
+        ((0.4 * (1/(validMove.moveFaceValue - WildCard(THREE, Diamond).intValue)))
+         + (0.2 * validMove.parity)
+         + (0.3 * 1 / GameUtilities.getNumberOfWildCardsInMove(validMove)))
   }
 
   /*
   Assumes that gameState is empty. If non-empty, use the heuristic function below this instead
   Assumes validMove comprises only of NormalCards
+  Using base as 3-intValue here because it is the lowest possible to play
    */
   def applyNormalCardHeuristicWithMoveSizeModifier(validMove: Move): Double = {
     (0.78d * (1d/(validMove.moveFaceValue - WildCard(THREE, Diamond).intValue)) + (0.22d * validMove.parity/Consants.maxMoveSize))
@@ -104,7 +106,7 @@ case object GameEngine {
   Penalizing the breaking of sets to play this move by giving a 0.78 weighting to holding on to sets
    */
   def applyNormalCardHeuristicWithPenaltyForBreakingSets(validMove: Move, gameState: Move, maxCards: Int): Double = {
-    ((0.22d * (1d/(validMove.moveFaceValue - gameState.moveFaceValue)))
+    ((0.22d * (1d/(validMove.moveFaceValue - gameState.moveFaceValue + 1)))
       + (0.78d * 1/(maxCards - validMove.numberOfNormalcards + 1)))
   }
 
@@ -133,6 +135,7 @@ case object GameEngine {
     try {
       Some(validMoves.moves
           .map(m => heuristic(m, gameState, playerIndicators))
+          .map(m => { println(m); m})
           .filter(validMoves => validMoves.likelihood > 0)
           .maxBy(_.likelihood))
     } catch {

--- a/src/main/scala/game/GameEngine.scala
+++ b/src/main/scala/game/GameEngine.scala
@@ -121,7 +121,7 @@ case object GameEngine {
   def getNextMoveWrapper(validMoves: Moves, gameState: Move)(implicit playerIndicators: PlayerIndicators): Option[Move] = {
     // If normal moves are available, play them first!
     if(!GameUtilities.isOnlySpecialMovesAvailable(validMoves)) {
-      val filteredValidMoves = GameUtilities.filterOnlyNormalCardMoves(validMoves)
+      val filteredValidMoves = GameUtilities.filterNonSpecialCardMoves(validMoves)
       getNextMove(filteredValidMoves, gameState)(getNormalCardMoveHeuristic, playerIndicators)
     } else {
       // If comprising ONLY of special moves, do nothing

--- a/src/main/scala/game/GameEngine.scala
+++ b/src/main/scala/game/GameEngine.scala
@@ -120,8 +120,12 @@ case object GameEngine {
   1. validMoves will comprise of moves with Special Cards (2s, Jokers) IFF no game.NormalCard moves are available
     1.1 Even then, there isnt a guarantee that the special card will be chosen
    */
-  def getNextMove(validMoves: Moves, gameState: Move)(heuristic: (Move, Move, PlayerIndicators) => Double, playerIndicators: PlayerIndicators): Option[Move] = {
-    if(validMoves.moves.size == 1) return Some(validMoves.moves.head)
+  def getNextMove(validMoves: Moves, gameState: Move)(heuristic: (Move, Move, PlayerIndicators) => Double,
+                                                      playerIndicators: PlayerIndicators): Option[Move] = {
+    /* If there is only one move left, and it is the only move available (not even valid), return it */
+    if(validMoves.moves.size == 1
+      && GameUtilities.getNewHand(playerIndicators.hand, Some(validMoves.moves.head)).listOfCards.isEmpty)
+      return Some(validMoves.moves.head)
     try {
       Some(
         validMoves.moves(validMoves.moves

--- a/src/main/scala/game/GameEssentials.scala
+++ b/src/main/scala/game/GameEssentials.scala
@@ -127,11 +127,13 @@ case class Hand(listOfCards: List[Card]) {
   We always want to minimize this
    */
   def weaknessFactor: Int = {
-    if(listOfSimilarCards.size == 1) 0 else {
-      var lastIntValueSeen  = listOfSimilarCards.tail.head.head.intValue
-      listOfSimilarCards
+    val intermediateListWithoutThrees = listOfSimilarCards.filter(listOfCard => listOfCard.head.intValue != 3)
+    if(listOfSimilarCards.size == 1 || intermediateListWithoutThrees.size == 1) 0
+    else {
+      var lastIntValueSeen  = intermediateListWithoutThrees.tail.head.head.intValue
+      intermediateListWithoutThrees
         .tail.tail
-        .foldLeft(listOfSimilarCards.tail.head.head.intValue - listOfSimilarCards.head.head.intValue)(
+        .foldLeft(intermediateListWithoutThrees.tail.head.head.intValue - intermediateListWithoutThrees.head.head.intValue)(
           (maxDifferenceSoFar, list) => {
             if (list.head.intValue - lastIntValueSeen > maxDifferenceSoFar) {
               val newDifference = list.head.intValue - lastIntValueSeen
@@ -211,6 +213,18 @@ case class Move(cards: List[Card], likelihood: Double = 0) {
       case c: NormalCard => c.intValue
     }
   }
+
+  /*
+  Override equals method to match on everything but likelihood
+   */
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case obj: Move => obj.canEqual(this) && this.cards == obj.cards
+      case _ => false
+    }
+  }
+
+  def canEqual(a: Any): Boolean = a.isInstanceOf[Move]
 }
 
 /*

--- a/src/main/scala/game/GameEssentials.scala
+++ b/src/main/scala/game/GameEssentials.scala
@@ -180,6 +180,10 @@ case class Move(cards: List[Card]) {
     }
   }
 
+  /*
+  Returns the highest card in the hand
+  Defined as card with strongest suit
+   */
   def highestCard: Card = {
     if(cards.size == 1) cards.head
     else {

--- a/src/main/scala/game/GameEssentials.scala
+++ b/src/main/scala/game/GameEssentials.scala
@@ -8,7 +8,6 @@ sealed trait Value
 sealed trait Card {
   def value: String = "game.Card"
   val intValue: Int
-  val isFaceCard: Boolean
 }
 
 case object Active extends PlayerStatus
@@ -43,14 +42,12 @@ case object Joker extends Card {
   override def toString: String = "<JOKER>"
   override def value: String = "JOKER"
   override val intValue: Int = -1
-  override val isFaceCard: Boolean = false
 }
 
 case class NormalCard(faceValue: Value, suit: Suit) extends Card {
   override def toString: String = "<" + faceValue.toString + "," + suit.toString + ">"
   override def value: String = faceValue.toString
   override val intValue: Int = faceValue match {
-    case THREE => 3
     case FOUR => 4
     case FIVE => 5
     case SIX => 6
@@ -62,9 +59,17 @@ case class NormalCard(faceValue: Value, suit: Suit) extends Card {
     case QUEEN => 12
     case KING => 13
     case ACE => 14
-    case _ => throw IllegalFaceValueException("Normal game.Card provided with illegal face value")
+    case _ => throw IllegalFaceValueException("NormalCard provided with illegal face value")
   }
-  override lazy val isFaceCard: Boolean = if(intValue > 10) true else false
+}
+
+case class WildCard(faceValue: Value, suit: Suit) extends Card {
+  override def toString: String = "<" + faceValue.toString + "," + suit.toString + ">"
+  override def value: String = faceValue.toString
+  override val intValue: Int = faceValue match {
+    case THREE => 3
+    case _ => throw IllegalFaceValueException("WildCard provided with illegal face value")
+  }
 }
 
 case class SpecialCard(faceValue: Value = TWO, suit: Suit) extends Card {
@@ -72,9 +77,8 @@ case class SpecialCard(faceValue: Value = TWO, suit: Suit) extends Card {
   override def value: String = faceValue.toString
   override val intValue: Int = faceValue match {
     case TWO => 2
-    case _ => throw IllegalFaceValueException("Special game.Card provided with illegal face value")
+    case _ => throw IllegalFaceValueException("SpecialCard provided with illegal face value")
   }
-  override val isFaceCard: Boolean = false
 }
 
 case class Hand(listOfCards: List[Card]) {

--- a/src/main/scala/game/GameEssentials.scala
+++ b/src/main/scala/game/GameEssentials.scala
@@ -171,7 +171,7 @@ case class Move(cards: List[Card]) {
   def moveFaceValue: Int = {
     if (cards.isEmpty) 0
     else {
-      cards.head match {
+      highestCard match {
         case w: WildCard => w.assumedValue
         case n: NormalCard => n.intValue
         case s: SpecialCard => s.intValue

--- a/src/main/scala/game/GameEssentials.scala
+++ b/src/main/scala/game/GameEssentials.scala
@@ -175,6 +175,7 @@ case class Move(cards: List[Card]) {
         case w: WildCard => w.assumedValue
         case n: NormalCard => n.intValue
         case s: SpecialCard => s.intValue
+        case joker: Card => joker.intValue
       }
     }
   }
@@ -189,6 +190,10 @@ case class Move(cards: List[Card]) {
     }
   }
   def parity: Int = cards.size
+  def numberOfNormalcards: Int = cards.count(card => card match {
+    case w: WildCard => false;
+    case _ => true
+  })
   def isEmpty: Boolean = cards.isEmpty
 
   /*

--- a/src/main/scala/game/GameEssentials.scala
+++ b/src/main/scala/game/GameEssentials.scala
@@ -201,8 +201,8 @@ case class Move(cards: List[Card], likelihood: Double = 0) {
   def parity: Int = cards.size
 
   def numberOfNormalcards: Int = cards.count(card => card match {
-    case w: WildCard => false;
-    case _ => true
+    case w: NormalCard => true
+    case _ => false
   })
 
   def isEmpty: Boolean = cards.isEmpty

--- a/src/main/scala/game/GameEssentials.scala
+++ b/src/main/scala/game/GameEssentials.scala
@@ -165,8 +165,9 @@ case class Hand(listOfCards: List[Card]) {
 /*
 A move is classified as a sorted List[game.Card] sorted as per numberToCardMap
  */
-case class Move(cards: List[Card]) {
-  override def toString: String = if(cards.nonEmpty) "game.Move(" + cards + ")" else "EMPTY"
+case class Move(cards: List[Card], likelihood: Double = 0) {
+  override def toString: String = if(cards.nonEmpty) "game.Move(" + cards + ")" +
+    (if (likelihood > 0) s"[$likelihood]" else "") else "EMPTY"
 
   def moveFaceValue: Int = {
     if (cards.isEmpty) 0

--- a/src/main/scala/game/GameEssentials.scala
+++ b/src/main/scala/game/GameEssentials.scala
@@ -63,8 +63,8 @@ case class NormalCard(faceValue: Value, suit: Suit) extends Card {
   }
 }
 
-case class WildCard(faceValue: Value, suit: Suit) extends Card {
-  override def toString: String = "<" + faceValue.toString + "," + suit.toString + ">"
+case class WildCard(faceValue: Value, suit: Suit, assumedValue: Int = 0) extends Card {
+  override def toString: String = "<" + faceValue.toString + "," + suit.toString + "(" + assumedValue + ")>"
   override def value: String = faceValue.toString
   override val intValue: Int = faceValue match {
     case THREE => 3
@@ -170,7 +170,13 @@ case class Move(cards: List[Card]) {
 
   def moveFaceValue: Int = {
     if (cards.isEmpty) 0
-    else cards.head.intValue
+    else {
+      cards.head match {
+        case w: WildCard => w.assumedValue
+        case n: NormalCard => n.intValue
+        case s: SpecialCard => s.intValue
+      }
+    }
   }
   def highestCard: Card = cards.last
   def parity: Int = cards.size

--- a/src/main/scala/game/GameEssentials.scala
+++ b/src/main/scala/game/GameEssentials.scala
@@ -179,8 +179,15 @@ case class Move(cards: List[Card]) {
     }
   }
 
-  // TODO - cannot always return last - what if the move is like this (3Spade, 8Diamond, 8Club) - 3spade aka 8Spade is the highest
-  def highestCard: Card = cards.last
+  def highestCard: Card = {
+    if(cards.size == 1) cards.head
+    else {
+      cards.foldLeft(cards.head)((highestCard, currentCard) =>
+        if(GameUtilities.cardOrderValue(currentCard) >
+          GameUtilities.cardOrderValue(highestCard)) currentCard
+        else highestCard)
+    }
+  }
   def parity: Int = cards.size
   def isEmpty: Boolean = cards.isEmpty
 

--- a/src/main/scala/game/GameEssentials.scala
+++ b/src/main/scala/game/GameEssentials.scala
@@ -178,6 +178,8 @@ case class Move(cards: List[Card]) {
       }
     }
   }
+
+  // TODO - cannot always return last - what if the move is like this (3Spade, 8Diamond, 8Club) - 3spade aka 8Spade is the highest
   def highestCard: Card = cards.last
   def parity: Int = cards.size
   def isEmpty: Boolean = cards.isEmpty

--- a/src/main/scala/game/GameEssentials.scala
+++ b/src/main/scala/game/GameEssentials.scala
@@ -185,7 +185,8 @@ case class Move(cards: List[Card], likelihood: Double = 0) {
 
   /*
   Returns the highest card in the hand
-  Defined as card with strongest suit
+  Defined as card with strongest suit === Highest cardOrderValue
+  In case of ties, picks the one first encountered
    */
   def highestCard: Card = {
     if(cards.size == 1) cards.head
@@ -196,23 +197,15 @@ case class Move(cards: List[Card], likelihood: Double = 0) {
         else highestCard)
     }
   }
+
   def parity: Int = cards.size
+
   def numberOfNormalcards: Int = cards.count(card => card match {
     case w: WildCard => false;
     case _ => true
   })
-  def isEmpty: Boolean = cards.isEmpty
 
-  /*
-  More thought needs to be put into this
-   */
-  def getMoveNormalCardModifier: Double = {
-    cards.head match {
-      case Joker => -1
-      case SpecialCard(_,_) => -1
-      case c: NormalCard => c.intValue
-    }
-  }
+  def isEmpty: Boolean = cards.isEmpty
 
   /*
   Override equals method to match on everything but likelihood

--- a/src/main/scala/game/GameUtilities.scala
+++ b/src/main/scala/game/GameUtilities.scala
@@ -266,6 +266,7 @@ case object GameUtilities {
 
   /*
   Applies all possible combinations of threes to allMoves and returns them
+  Assumes inbound moves do not contain any WildCards
    */
   def addThreesToMoves(allMoves: Moves, listOfThrees: List[Card]): Moves = {
     if(listOfThrees.isEmpty) allMoves
@@ -279,6 +280,7 @@ case object GameUtilities {
       // Apply 3s only on NormalMoves, cannot apply with special cards
       val listOfCardsInNormalMoves: List[List[Card]] = allMoves.moves.filter(move => move match {
         case Move(List(NormalCard(_,_), _*), _) => true
+        case Move(List(WildCard(_,_,_), _*), _) => throw IllegalMoveSuppliedException("This method does not accept WildCard as part of allMoves")
         case _ => false
       }).map(move => move.cards)
       val listOfSpecialMoves = allMoves.moves.filter(move => move match {
@@ -291,6 +293,8 @@ case object GameUtilities {
         allPossibleCombinationsOfThrees.filter(l => l.nonEmpty).map(listOfCard => Move(listOfCard)) ++
         listOfSpecialMoves
 
+      // Making 3s assume values of the set they're a part of, or ACE for now
+      // Cards get reassigned values later if they can be used to burn
       Moves(totalMoves
         .map(move => move.cards)
           .map(listOfCard =>

--- a/src/main/scala/game/GameUtilities.scala
+++ b/src/main/scala/game/GameUtilities.scala
@@ -210,12 +210,16 @@ case object GameUtilities {
   def cardOrderValue(card: Card): Int = {
     card match {
       case n: NormalCard => numberToCardMap.find(_._2 == n).map(_._1).getOrElse(-1)
-      case w: WildCard => numberToCardMap.find(_._2 ==
-        /* Defaulting to a FOUR for now, look over this later. Theoretically, this shouldn't happen ever. */
-        NormalCard(numberToFaceValueMap.getOrElse(w.assumedValue, FOUR), w.suit)).map(_._1).getOrElse(-1)
+      case w: WildCard => numberToCardMap.find(_._2 == getCardAssumedByWildCard(w)).map(_._1).getOrElse(-1)
     }
-
   }
+
+  /*
+  Returns the NormalCard assumed by a wildcard, given its assumed value
+  Defaulting to a FOUR for now, look over this later. Theoretically, this shouldn't happen ever.
+  */
+
+  def getCardAssumedByWildCard(w: WildCard): NormalCard = NormalCard(numberToFaceValueMap.getOrElse(w.assumedValue, FOUR), w.suit)
 
   def isOnlySpecialMovesAvailable(validMoves: Moves): Boolean = {
     validMoves.moves.foldLeft(true)((acc, move) => move.cards match {
@@ -265,7 +269,7 @@ case object GameUtilities {
         .map(set => set.toList)
 
       // Apply 3s only on NormalMoves, cannot apply with special cards
-      val listOfCardsInNormalMoves = allMoves.moves.filter(move => move match {
+      val listOfCardsInNormalMoves: List[List[Card]] = allMoves.moves.filter(move => move match {
         case Move(List(NormalCard(_,_), _*)) => true
         case _ => false
       }).map(move => move.cards)

--- a/src/main/scala/game/GameUtilities.scala
+++ b/src/main/scala/game/GameUtilities.scala
@@ -362,6 +362,34 @@ case object GameUtilities {
   3. It's assumedValue changes to that of gameState.moveFaceValue + 1, if gameState is not an ACE
    */
   def assignWildCardsOptimally(validMoves: Moves, gameState: Move): Moves = {
-    validMoves
+    Moves(validMoves.moves
+      .map(move => if(GameUtilities.getNumberOfWildCardsInMove(move) == move.parity)
+                      getOptimalWildCardValue(move, gameState)
+                    else move))
   }
+
+  /*
+  Assumption - the move is comprised entirely of 3s
+  It is also a valid move given the gameState
+  Example :- 3(A)-3(A) on top of 9-9
+   */
+  def getOptimalWildCardValue(validMove: Move, gameState: Move): Move = {
+    if(GameUtilities.getNumberOfWildCardsInMove(validMove) != validMove.parity) throw IllegalMoveSuppliedException("Function only accept moves comprised completely of WildCards")
+    else if (gameState.parity == 0) validMove  /* Return highest possible assumed value if gameState is empty */
+    else {
+      validMove.highestCard match {
+        case w: WildCard =>
+          if(cardOrderValue(w.copy(assumedValue=gameState.moveFaceValue)) > cardOrderValue(gameState.highestCard)) {
+            Move(validMove.cards.map(card => card match {
+              case w: WildCard => w.copy(assumedValue=gameState.moveFaceValue)
+              case c: Card => c
+            }))
+          }
+          else validMove
+        case _ => validMove
+      }
+    }
+  }
+
+  case class IllegalMoveSuppliedException(s: String) extends IllegalArgumentException(s)
 }

--- a/src/main/scala/game/GameUtilities.scala
+++ b/src/main/scala/game/GameUtilities.scala
@@ -278,12 +278,12 @@ case object GameUtilities {
 
       // Apply 3s only on NormalMoves, cannot apply with special cards
       val listOfCardsInNormalMoves: List[List[Card]] = allMoves.moves.filter(move => move match {
-        case Move(List(NormalCard(_,_), _*)) => true
+        case Move(List(NormalCard(_,_), _*), _) => true
         case _ => false
       }).map(move => move.cards)
       val listOfSpecialMoves = allMoves.moves.filter(move => move match {
-        case Move(List(Joker)) => true
-        case Move(List(SpecialCard(_,_), _*)) => true
+        case Move(List(Joker), _) => true
+        case Move(List(SpecialCard(_,_), _*), _) => true
         case _ => false
       })
 

--- a/src/main/scala/game/GameUtilities.scala
+++ b/src/main/scala/game/GameUtilities.scala
@@ -209,8 +209,8 @@ case object GameUtilities {
 
   def cardOrderValue(card: Card): Int = {
     card match {
-      case n: NormalCard => numberToCardMap.find(_._2 == n).map(_._1).getOrElse(-1)
       case w: WildCard => numberToCardMap.find(_._2 == getCardAssumedByWildCard(w)).map(_._1).getOrElse(-1)
+      case _ => numberToCardMap.find(_._2 == card).map(_._1).getOrElse(-1)
     }
   }
 
@@ -317,4 +317,7 @@ case object GameUtilities {
       case _: Exception => List.empty
     }
   }
+
+  def getNumberOfWildCardsInMove(validMove: Move): Int =
+    validMove.cards.foldLeft(0)((total, card) => card match {case c: WildCard => total + 1; case _ => total})
 }

--- a/src/main/scala/game/GameUtilities.scala
+++ b/src/main/scala/game/GameUtilities.scala
@@ -368,7 +368,7 @@ case object GameUtilities {
   def assignWildCardsOptimally(validMoves: Moves, gameState: Move): Moves = {
     Moves(validMoves.moves
       .map(move => if(GameUtilities.getNumberOfWildCardsInMove(move) == move.parity)
-                      getOptimalWildCardValue(move, gameState)
+                      getMoveWithOptimalWildCardValue(move, gameState)
                     else move))
   }
 
@@ -377,7 +377,7 @@ case object GameUtilities {
   It is also a valid move given the gameState
   Example :- 3(A)-3(A) on top of 9-9
    */
-  def getOptimalWildCardValue(validMove: Move, gameState: Move): Move = {
+  def getMoveWithOptimalWildCardValue(validMove: Move, gameState: Move): Move = {
     if(GameUtilities.getNumberOfWildCardsInMove(validMove) != validMove.parity) throw IllegalMoveSuppliedException("Function only accept moves comprised completely of WildCards")
     else if (gameState.parity == 0) validMove  /* Return highest possible assumed value if gameState is empty */
     else {

--- a/src/main/scala/game/GameUtilities.scala
+++ b/src/main/scala/game/GameUtilities.scala
@@ -328,4 +328,25 @@ case object GameUtilities {
 
   def getNumberOfWildCardsInMove(validMove: Move): Int =
     validMove.cards.foldLeft(0)((total, card) => card match {case c: WildCard => total + 1; case _ => total})
+
+  /*
+  Returns the new hand comprising of cards from currentHand that do not appear in movePlayed
+   */
+  def getNewHand(currentHand: Hand, movePlayed: Option[Move]): Hand = {
+    movePlayed.getOrElse(None) match {
+      case move: Move => Hand(
+        currentHand
+          .listOfCards
+          .filter(c => c match {
+            case w: WildCard =>
+              if(move.cards.exists(mc => mc match {
+                case mwc: WildCard => mwc.suit == w.suit
+                case _ => false
+              })) false
+              else true
+            case _ => !move.cards.contains(c)
+          }))
+      case None => currentHand
+    }
+  }
 }

--- a/src/main/scala/game/GameUtilities.scala
+++ b/src/main/scala/game/GameUtilities.scala
@@ -1,6 +1,7 @@
 package game
 
-import game.FaceValue.FOUR
+import game.FaceValue.{ACE, FOUR}
+import game.Suits.Spade
 import player.{Player, PlayerIndicators}
 import utils.Consants
 import utils.Consants._
@@ -287,7 +288,7 @@ case object GameUtilities {
                 case w: WildCard => true
                 case e => false })) {
                 listOfCard.map {
-                  case w: WildCard => w.copy(assumedValue = 14) // Value for ACE right now
+                  case w: WildCard => w.copy(assumedValue = NormalCard(ACE, Spade).intValue)
                   case e => e
                 }
               }

--- a/src/main/scala/game/GameUtilities.scala
+++ b/src/main/scala/game/GameUtilities.scala
@@ -185,7 +185,6 @@ case object GameUtilities {
                     case other => return move.parity == other - 1
                   }
       }
-
     }
 
     if(move.parity != gameState.parity) false
@@ -204,8 +203,17 @@ case object GameUtilities {
   // 1. move1 and move2 are not EMPTY moves
   // 2. move1 and move2 have same parity - same size of cards
   //    - only exception to the above is 2s and JOKERs
-  def checkIfBetter(move1: Move, move2: Move): Boolean =
-    cardOrderValue(move1.highestCard) > cardOrderValue(move2.highestCard)
+  def checkIfBetter(move1: Move, move2: Move): Boolean = {
+    // This is the case in which 3s are involved, leading to assumedCard being same as original NormalCard
+    if (cardOrderValue(move1.highestCard) == cardOrderValue(move2.highestCard)) {
+      move2.highestCard match {
+        case w: WildCard => true
+        case _ => false
+      }
+    }
+    else cardOrderValue(move1.highestCard) > cardOrderValue(move2.highestCard)
+  }
+
 
   def cardOrderValue(card: Card): Int = {
     card match {

--- a/src/main/scala/game/GameUtilities.scala
+++ b/src/main/scala/game/GameUtilities.scala
@@ -349,4 +349,19 @@ case object GameUtilities {
       case None => currentHand
     }
   }
+
+  /*
+  Takes in a list of valid moves and assigns dangling wildcards optimal assumedValues
+  A Dangling Wilcards is defined as a 3 or a set of 3s being played by themself, instead of with a NormalCard
+  For example, upon entry into this function, a Move such as <3> or <3-3> would be assumed to be ACEs by default
+  However, this isnt optimal, and it only suffices for checking validity of move
+  Ideally, the <3> or <3-3> would assume value based on gameState
+  This comes in one of three scenarios :-
+  1. It maintains its assumedValue (highest possible faceValue of card)
+  2. It's assumedValue changes to that of gameState.moveFaceValue, if doing so burns the game state
+  3. It's assumedValue changes to that of gameState.moveFaceValue + 1, if gameState is not an ACE
+   */
+  def assignWildCardsOptimally(validMoves: Moves, gameState: Move): Moves = {
+    validMoves
+  }
 }

--- a/src/main/scala/game/Round.scala
+++ b/src/main/scala/game/Round.scala
@@ -2,14 +2,40 @@ package game
 
 import player.Player
 
-
-
 case class Round(gameState: Move,
                  lastMovePlayedBy: String,
                  totalNumberOfPlayers: Int,
                  currentPlayerTurn: Int,
                  listOfPlayers: List[Player],
                  roundPassStatus: List[Boolean]) {
+
+  /* Gets the index of the NEXT player who is supposed to play.
+     Defined by the original list of players name
+    */
+  def getIndexOfNextPlayer: Int = {
+    val originalIndexOfPlayerWhoPlayedLastMove: Int = Round.initialListOfPlayerNames
+      .zipWithIndex
+      .filter {
+        case (name, _) => name == lastMovePlayedBy
+      }
+      .map {
+        case (_, index) => index
+      }
+      .head
+
+    var nextPlayerOriginalIndex = if(originalIndexOfPlayerWhoPlayedLastMove + 1 == Round.initialListOfPlayerNames.size) 0
+                                  else originalIndexOfPlayerWhoPlayedLastMove + 1
+    var playerSupposedToPlayNext: String = Round.initialListOfPlayerNames(nextPlayerOriginalIndex)
+
+    while(!listOfPlayers.map(p => p.name).contains(playerSupposedToPlayNext)) {
+       nextPlayerOriginalIndex = if(nextPlayerOriginalIndex + 1 == Round.initialListOfPlayerNames.size) 0
+                                 else nextPlayerOriginalIndex + 1
+      playerSupposedToPlayNext = Round.initialListOfPlayerNames(nextPlayerOriginalIndex)
+    }
+
+    getIndexOf(playerSupposedToPlayNext)
+
+  }
 
   /*
   Return TRUE if everyone has passed, except for the person who played the last move
@@ -61,12 +87,25 @@ case class Round(gameState: Move,
       .head
   }
 
+  /*
+  Updated roundPassStatus having removed the element at the index specified
+  This is used when a player has exited the game and everything needs to be augmented
+   */
+  def updatedRoundPassStatus(indexToRemove: Int): List[Boolean] = {
+    val tempBuffer = roundPassStatus.toBuffer
+    tempBuffer.remove(indexToRemove)
+    tempBuffer.toList
+  }
+
 }
 
 object Round {
   def getNoPassList(numberOfPlayers: Int): List[Boolean] = {
     (1 to numberOfPlayers).toList.map(_ => false)
   }
+
+  /* Maintains the initial list of playernames for future tracking */
+  var initialListOfPlayerNames: List[String] = List.empty
 
   /*
   Throws exception if player names are not unique

--- a/src/main/scala/game/Round.scala
+++ b/src/main/scala/game/Round.scala
@@ -9,7 +9,8 @@ case class Round(gameState: Move,
                  listOfPlayers: List[Player],
                  roundPassStatus: List[Boolean]) {
 
-  /* Gets the index of the NEXT player who is supposed to play.
+  /* Used when round.lastMovePlayedBy is played by someone who does not exist anymore (completed)
+     Gets the index of the NEXT player who is supposed to play.
      Defined by the original list of players name
     */
   def getIndexOfNextPlayer: Int = {

--- a/src/main/scala/player/Player.scala
+++ b/src/main/scala/player/Player.scala
@@ -21,7 +21,8 @@ case class Player(name: String, hand: Hand) {
     val allMoves: Moves = addThreesToMoves(allMovesWithoutThrees, listOfThreesInHand)
     val validMoves: Moves = getValidMoves(allMoves, currentState)
     val validMovesWithWildCardsOptimallyAssigned: Moves = assignWildCardsOptimally(validMoves, currentState)
-    getNextMoveWrapper(validMovesWithWildCardsOptimallyAssigned, currentState)
+    val nextMove: Option[Move] = getNextMoveWrapper(validMovesWithWildCardsOptimallyAssigned, currentState)
+    nextMove
   }
 
 }

--- a/src/main/scala/player/Player.scala
+++ b/src/main/scala/player/Player.scala
@@ -23,26 +23,6 @@ case class Player(name: String, hand: Hand) {
     getNextMoveWrapper(validMoves, currentState)
   }
 
-  /*
-  Returns the new hand comprising of cards from currentHand that do not appear in movePlayed
-   */
-  def getNewHand(currentHand: Hand, movePlayed: Option[Move]): Hand = {
-    movePlayed.getOrElse(None) match {
-      case move: Move => Hand(
-        currentHand
-          .listOfCards
-          .filter(c => c match {
-            case w: WildCard =>
-              if(move.cards.exists(mc => mc match {
-                case mwc: WildCard => mwc.suit == w.suit
-                case _ => false
-              })) false
-              else true
-            case _ => !move.cards.contains(c)
-          }))
-      case None => currentHand
-    }
-  }
 }
 
 

--- a/src/main/scala/player/Player.scala
+++ b/src/main/scala/player/Player.scala
@@ -20,7 +20,8 @@ case class Player(name: String, hand: Hand) {
     val allMovesWithoutThrees: Moves = getAllMoves(intermediateListsWithoutThrees)
     val allMoves: Moves = addThreesToMoves(allMovesWithoutThrees, listOfThreesInHand)
     val validMoves: Moves = getValidMoves(allMoves, currentState)
-    getNextMoveWrapper(validMoves, currentState)
+    val validMovesWithWildCardsOptimallyAssigned: Moves = assignWildCardsOptimally(validMoves, currentState)
+    getNextMoveWrapper(validMovesWithWildCardsOptimallyAssigned, currentState)
   }
 
 }

--- a/src/main/scala/player/Player.scala
+++ b/src/main/scala/player/Player.scala
@@ -59,6 +59,13 @@ case object PlayerIndicators {
       case _ => 0
     }
   }
+
+  /*
+  Returns 0-1 value giving the penalty modifier for wildcards as a function of hand size
+   */
+  def applyWildCardPenaltyModifer(sizeOfHand: Int): Double = {
+    1 /(1 + scala.math.exp(-((0.5d * sizeOfHand) - 4)))
+  }
 }
 
 
@@ -68,6 +75,7 @@ case class PlayerIndicators(hand: Hand) {
 
   // Likelihood of playing a special card. Increases as the game moves on (hand nears empty)
   lazy val specialCardModifier: Double = applyCustomSpecialCardModifier(hand.listOfCards.size)/100
+  lazy val wildCardPenaltyModifier: Double = applyWildCardPenaltyModifer(hand.listOfCards.size)
   lazy val highCardModifier: Double =  if(hand.delta == 0) 1d else 1d/hand.delta
 
   /*

--- a/src/main/scala/player/Player.scala
+++ b/src/main/scala/player/Player.scala
@@ -15,7 +15,10 @@ case class Player(name: String, hand: Hand) {
   def playNextMove(currentHand: Hand, currentState: Move): Option[Move] = {
     val sortedHand = Hand(sortCards(currentHand.listOfCards))
     val intermediateLists: List[List[Card]] = getListsOfSimilarCards(sortedHand)
-    val allMoves: Moves = getAllMoves(intermediateLists)
+    val intermediateListsWithoutThrees: List[List[Card]] = intermediateLists.filter(list => list.head.intValue != 3)
+    val listOfThreesInHand: List[Card] = getWildCardListFromIntermediateList(intermediateLists)
+    val allMovesWithoutThrees: Moves = getAllMoves(intermediateListsWithoutThrees)
+    val allMoves: Moves = addThreesToMoves(allMovesWithoutThrees, listOfThreesInHand)
     val validMoves: Moves = getValidMoves(allMoves, currentState)
     getNextMoveWrapper(validMoves, currentState)
   }

--- a/src/main/scala/player/Player.scala
+++ b/src/main/scala/player/Player.scala
@@ -87,8 +87,8 @@ case class PlayerIndicators(hand: Hand) {
   If not, leads to an exception being thrown, and the nextMove defaulting to None
    */
   def getListSetSizeForCard(validMove: Move): Int = {
-    // If the move is comprised entirely of wildcards, then return parity of move
-    if(GameUtilities.getNumberOfWildCardsInMove(validMove) == validMove.parity) validMove.parity
+    // If the move is comprised entirely of wildcards, then return 0
+    if(GameUtilities.getNumberOfWildCardsInMove(validMove) == validMove.parity) 0
     else hand.listOfSimilarCards.filter(l => l.head.intValue == validMove.moveFaceValue).head.size
   }
 

--- a/src/main/scala/player/Player.scala
+++ b/src/main/scala/player/Player.scala
@@ -87,8 +87,8 @@ case class PlayerIndicators(hand: Hand) {
   If not, leads to an exception being thrown, and the nextMove defaulting to None
    */
   def getListSetSizeForCard(validMove: Move): Int = {
-    // If the move is comprised entirely of wildcards, then return 0
-    if(GameUtilities.getNumberOfWildCardsInMove(validMove) == validMove.parity) 0
+    // If the move is comprised entirely of wildcards, then parity of move itself
+    if(GameUtilities.getNumberOfWildCardsInMove(validMove) == validMove.parity) validMove.parity
     else hand.listOfSimilarCards.filter(l => l.head.intValue == validMove.moveFaceValue).head.size
   }
 

--- a/src/main/scala/utils/Consants.scala
+++ b/src/main/scala/utils/Consants.scala
@@ -151,4 +151,74 @@ object Consants {
     14 -> ACE
   )
 
+  /*
+  These are all shorthand method for defining cards
+  Aids in clarity of code later
+   */
+  def THREE_Diamond: WildCard = WildCard(THREE, Diamond)
+  def THREE_Club: WildCard = WildCard(THREE, Club)
+  def THREE_Heart: WildCard = WildCard(THREE, Heart)
+  def THREE_Spade: WildCard = WildCard(THREE, Spade)
+
+  def FOUR_Diamond: NormalCard = NormalCard(FOUR, Diamond)
+  def FOUR_Club: NormalCard = NormalCard(FOUR, Club)
+  def FOUR_Heart: NormalCard = NormalCard(FOUR, Heart)
+  def FOUR_Spade: NormalCard = NormalCard(FOUR, Spade)
+
+  def FIVE_Diamond: NormalCard = NormalCard(FIVE, Diamond)
+  def FIVE_Club: NormalCard = NormalCard(FIVE, Club)
+  def FIVE_Heart: NormalCard = NormalCard(FIVE, Heart)
+  def FIVE_Spade: NormalCard = NormalCard(FIVE, Spade)
+
+  def SIX_Diamond: NormalCard = NormalCard(SIX, Diamond)
+  def SIX_Club: NormalCard = NormalCard(SIX, Club)
+  def SIX_Heart: NormalCard = NormalCard(SIX, Heart)
+  def SIX_Spade: NormalCard = NormalCard(SIX, Spade)
+
+  def SEVEN_Diamond: NormalCard = NormalCard(SEVEN, Diamond)
+  def SEVEN_Club: NormalCard = NormalCard(SEVEN, Club)
+  def SEVEN_Heart: NormalCard = NormalCard(SEVEN, Heart)
+  def SEVEN_Spade: NormalCard = NormalCard(SEVEN, Spade)
+
+  def EIGHT_Diamond: NormalCard = NormalCard(EIGHT, Diamond)
+  def EIGHT_Club: NormalCard = NormalCard(EIGHT, Club)
+  def EIGHT_Heart: NormalCard = NormalCard(EIGHT, Heart)
+  def EIGHT_Spade: NormalCard = NormalCard(EIGHT, Spade)
+
+  def NINE_Diamond: NormalCard = NormalCard(NINE, Diamond)
+  def NINE_Club: NormalCard = NormalCard(NINE, Club)
+  def NINE_Heart: NormalCard = NormalCard(NINE, Heart)
+  def NINE_Spade: NormalCard = NormalCard(NINE, Spade)
+
+  def TEN_Diamond: NormalCard = NormalCard(TEN, Diamond)
+  def TEN_Club: NormalCard = NormalCard(TEN, Club)
+  def TEN_Heart: NormalCard = NormalCard(TEN, Heart)
+  def TEN_Spade: NormalCard = NormalCard(TEN, Spade)
+
+  def JACK_Diamond: NormalCard = NormalCard(JACK, Diamond)
+  def JACK_Club: NormalCard = NormalCard(JACK, Club)
+  def JACK_Heart: NormalCard = NormalCard(JACK, Heart)
+  def JACK_Spade: NormalCard = NormalCard(JACK, Spade)
+
+  def QUEEN_Diamond: NormalCard = NormalCard(QUEEN, Diamond)
+  def QUEEN_Club: NormalCard = NormalCard(QUEEN, Club)
+  def QUEEN_Heart: NormalCard = NormalCard(QUEEN, Heart)
+  def QUEEN_Spade: NormalCard = NormalCard(QUEEN, Spade)
+
+  def KING_Diamond: NormalCard = NormalCard(KING, Diamond)
+  def KING_Club: NormalCard = NormalCard(KING, Club)
+  def KING_Heart: NormalCard = NormalCard(KING, Heart)
+  def KING_Spade: NormalCard = NormalCard(KING, Spade)
+
+  def ACE_Diamond: NormalCard = NormalCard(ACE, Diamond)
+  def ACE_Club: NormalCard = NormalCard(ACE, Club)
+  def ACE_Heart: NormalCard = NormalCard(ACE, Heart)
+  def ACE_Spade: NormalCard = NormalCard(ACE, Spade)
+
+  def TWO_Diamond: SpecialCard = SpecialCard(TWO, Diamond)
+  def TWO_Club: SpecialCard = SpecialCard(TWO, Club)
+  def TWO_Heart: SpecialCard = SpecialCard(TWO, Heart)
+  def TWO_Spade: SpecialCard = SpecialCard(TWO, Spade)
+
+
 }

--- a/src/main/scala/utils/Consants.scala
+++ b/src/main/scala/utils/Consants.scala
@@ -160,6 +160,11 @@ object Consants {
   def THREE_Heart: WildCard = WildCard(THREE, Heart)
   def THREE_Spade: WildCard = WildCard(THREE, Spade)
 
+  def THREE_Diamond(assumedValue: Int): WildCard = WildCard(THREE, Diamond, assumedValue)
+  def THREE_Club(assumedValue: Int): WildCard = WildCard(THREE, Club, assumedValue)
+  def THREE_Heart(assumedValue: Int): WildCard = WildCard(THREE, Heart, assumedValue)
+  def THREE_Spade(assumedValue: Int): WildCard = WildCard(THREE, Spade, assumedValue)
+
   def FOUR_Diamond: NormalCard = NormalCard(FOUR, Diamond)
   def FOUR_Club: NormalCard = NormalCard(FOUR, Club)
   def FOUR_Heart: NormalCard = NormalCard(FOUR, Heart)
@@ -219,6 +224,5 @@ object Consants {
   def TWO_Club: SpecialCard = SpecialCard(TWO, Club)
   def TWO_Heart: SpecialCard = SpecialCard(TWO, Heart)
   def TWO_Spade: SpecialCard = SpecialCard(TWO, Spade)
-
 
 }

--- a/src/main/scala/utils/Consants.scala
+++ b/src/main/scala/utils/Consants.scala
@@ -2,7 +2,7 @@ package utils
 
 import game.FaceValue._
 import game.Suits._
-import game.{Card, Hand, Joker, NormalCard, SpecialCard, WildCard}
+import game.{Card, Hand, Joker, NormalCard, SpecialCard, Value, WildCard}
 
 object Consants {
 
@@ -136,5 +136,19 @@ object Consants {
     Joker,
     Joker,
   ))
+
+  val numberToFaceValueMap: Map[Int, Value] = Map(
+    4 -> FOUR,
+    5 -> FIVE,
+    6 -> SIX,
+    7 -> SEVEN,
+    8 -> EIGHT,
+    9 -> NINE,
+    10 -> TEN,
+    11-> JACK,
+    12 -> QUEEN,
+    13 -> KING,
+    14 -> ACE
+  )
 
 }

--- a/src/main/scala/utils/Consants.scala
+++ b/src/main/scala/utils/Consants.scala
@@ -2,7 +2,7 @@ package utils
 
 import game.FaceValue._
 import game.Suits._
-import game.{Card, Hand, Joker, NormalCard, SpecialCard}
+import game.{Card, Hand, Joker, NormalCard, SpecialCard, WildCard}
 
 object Consants {
 
@@ -11,10 +11,10 @@ object Consants {
   val maxMoveSize = 4
 
   val numberToCardMap: Map[Int, Card] = Map(
-    0 -> NormalCard(THREE, Diamond),
-    1 -> NormalCard(THREE, Club),
-    2 -> NormalCard(THREE, Heart),
-    3 -> NormalCard(THREE, Spade),
+    0 -> WildCard(THREE, Diamond),
+    1 -> WildCard(THREE, Club),
+    2 -> WildCard(THREE, Heart),
+    3 -> WildCard(THREE, Spade),
 
     4 -> NormalCard(FOUR, Diamond),
     5 -> NormalCard(FOUR, Club),
@@ -81,10 +81,10 @@ object Consants {
   )
 
   val sortedHandWithAllCards: Hand = Hand(List(
-    NormalCard(THREE, Diamond),
-    NormalCard(THREE, Club),
-    NormalCard(THREE, Heart),
-    NormalCard(THREE, Spade),
+    WildCard(THREE, Diamond),
+    WildCard(THREE, Club),
+    WildCard(THREE, Heart),
+    WildCard(THREE, Spade),
     NormalCard(FOUR, Diamond),
     NormalCard(FOUR, Club),
     NormalCard(FOUR, Heart),

--- a/src/test/scala/DevelopmentTest.scala
+++ b/src/test/scala/DevelopmentTest.scala
@@ -107,11 +107,12 @@ class DevelopmentTest extends FunSpec {
         Move(List(NormalCard(ACE, Diamond), NormalCard(ACE, Club)))))
 
 
-      val testMove = Move(List(
+      val testMove = Move(List(WildCard(THREE, Diamond, 7), WildCard(THREE, Club, 7), WildCard(THREE, Heart, 7), WildCard(THREE, Spade, 7),
         NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club), NormalCard(SEVEN, Heart), NormalCard(SEVEN, Spade)
       ))
       println("-------------")
       println(testMove.highestCard)
+      println(testMove.cards.forall(card => card match {case n: NormalCard => true; case _ => false}))
 
     }
   }

--- a/src/test/scala/DevelopmentTest.scala
+++ b/src/test/scala/DevelopmentTest.scala
@@ -72,12 +72,12 @@ class DevelopmentTest extends FunSpec {
       //      println(single9 +  " : " + game.GameUtilities.getNormalCardMoveHeuristic(single9, gameState, playerIndicators).toString)
       //      println(single10 +  " : " + game.GameUtilities.getNormalCardMoveHeuristic(single10, gameState, playerIndicators).toString)
       //      println(singleJack +  " : " + game.GameUtilities.getNormalCardMoveHeuristic(singleJack, gameState, playerIndicators).toString)
-      println(single8D +  " : " + GameEngine.getNormalCardMoveHeuristic(single8D, gameState, playerIndicators).toString)
-      println(doubleQueen +  " : " + GameEngine.getNormalCardMoveHeuristic(doubleQueen, gameState, playerIndicators).toString)
-      println(single2D +  " : " + GameEngine.getSpecialCardMoveHeuristic(single2D, gameState, playerIndicators).toString)
-      println(single2C +  " : " + GameEngine.getSpecialCardMoveHeuristic(single2C, gameState, playerIndicators).toString)
-      println(single2H +  " : " + GameEngine.getSpecialCardMoveHeuristic(single2H, gameState, playerIndicators).toString)
-      println(joker +  " : " + GameEngine.getSpecialCardMoveHeuristic(joker, gameState, playerIndicators).toString)
+      println(single8D +  " : " + GameEngine.applyNormalCardMoveHeuristic(single8D, gameState, playerIndicators).toString)
+      println(doubleQueen +  " : " + GameEngine.applyNormalCardMoveHeuristic(doubleQueen, gameState, playerIndicators).toString)
+      println(single2D +  " : " + GameEngine.applySpecialCardMoveHeuristic(single2D, gameState, playerIndicators).toString)
+      println(single2C +  " : " + GameEngine.applySpecialCardMoveHeuristic(single2C, gameState, playerIndicators).toString)
+      println(single2H +  " : " + GameEngine.applySpecialCardMoveHeuristic(single2H, gameState, playerIndicators).toString)
+      println(joker +  " : " + GameEngine.applySpecialCardMoveHeuristic(joker, gameState, playerIndicators).toString)
 
       val validMoves = Moves(List(single8D, doubleQueen, single2D, single2C, single2H, two2s, three2s, joker))
       println("Is only special moves available " + GameUtilities.isOnlySpecialMovesAvailable(validMoves) )
@@ -154,8 +154,8 @@ class DevelopmentTest extends FunSpec {
       val otherMove = Move(List(WildCard(THREE, Heart, 13), NormalCard(KING, Heart)))
       val gs = Move(List(NormalCard(NINE, Heart), NormalCard(NINE, Spade)))
 
-      println(GameEngine.getNormalCardMoveHeuristic(double10s, gs, PlayerIndicators(observedHand)))
-      println(GameEngine.getNormalCardMoveHeuristic(otherMove, gs, PlayerIndicators(observedHand)))
+      println(GameEngine.applyNormalCardMoveHeuristic(double10s, gs, PlayerIndicators(observedHand)))
+      println(GameEngine.applyNormalCardMoveHeuristic(otherMove, gs, PlayerIndicators(observedHand)))
 
       val single3 = Move(List(WildCard(THREE, Diamond, 14)))
 
@@ -163,7 +163,7 @@ class DevelopmentTest extends FunSpec {
 
       val aHand = Hand(List(WildCard(THREE, Diamond), SpecialCard(TWO, Diamond)))
 
-      println(GameEngine.getNormalCardMoveHeuristic(single3, Move(List.empty), PlayerIndicators(aHand)))
+      println(GameEngine.applyNormalCardMoveHeuristic(single3, Move(List.empty), PlayerIndicators(aHand)))
       println(GameEngine.applyNormalCardHeuristicWithMoveSizeModifier(single3))
       println(GameEngine.wildCardUsagePenalty(single3))
 
@@ -188,6 +188,18 @@ class DevelopmentTest extends FunSpec {
       val m2 = Move(List(WildCard(THREE, Club, 14), WildCard(THREE, Spade, 7)))
 
       println(GameUtilities.checkIfBetter(m1, m2))
+
+
+      val gs = Move(List(NormalCard(SIX, Spade)))
+      val pHand = Hand(List(
+        WildCard(THREE, Diamond),
+        NormalCard(EIGHT, Diamond), NormalCard(EIGHT, Heart),NormalCard(EIGHT, Spade),
+        NormalCard(KING, Diamond),NormalCard(KING, Spade),
+        SpecialCard(TWO, Club)
+      ))
+
+      // Here, K-diamond is preferred over playing the 3 - this is WRONG!
+//      val m1 =
 
     }
 

--- a/src/test/scala/DevelopmentTest.scala
+++ b/src/test/scala/DevelopmentTest.scala
@@ -265,6 +265,10 @@ class DevelopmentTest extends FunSpec {
       println(GameEngine.applyNormalCardMoveHeuristic(m2, gameState, pi).likelihood + GameEngine.wildCardUsagePenalty(m2, pi.wildCardPenaltyModifier))
       println(GameEngine.wildCardUsagePenalty(m2, pi.wildCardPenaltyModifier))
 
+
+
+      println("0000")
+      println(PlayerIndicators.applyWildCardPenaltyModifer(0))
     }
 
   }

--- a/src/test/scala/DevelopmentTest.scala
+++ b/src/test/scala/DevelopmentTest.scala
@@ -173,6 +173,7 @@ class DevelopmentTest extends FunSpec {
       println(move1.highestCard)
       println(move2.highestCard)
       println(GameUtilities.checkIfBetter(move1, move2))
+      print(GameUtilities.getNextGameState(move1, Some(move2)))
 
     }
 

--- a/src/test/scala/DevelopmentTest.scala
+++ b/src/test/scala/DevelopmentTest.scala
@@ -269,6 +269,16 @@ class DevelopmentTest extends FunSpec {
 
       println("0000")
       println(PlayerIndicators.applyWildCardPenaltyModifer(0))
+
+    }
+
+
+    it("faillign tst") {
+      val move1 = Move(List(THREE_Club(5), THREE_Heart(5), THREE_Spade(5), FIVE_Spade))
+      val move2 = Move(List(THREE_Club(5), THREE_Heart(5), THREE_Club(5), THREE_Spade(5)))
+      val m = 0.9706877692486436
+      println(GameEngine.wildCardUsagePenalty(move1, m))
+      println(GameEngine.wildCardUsagePenalty(move2, m))
     }
 
   }

--- a/src/test/scala/DevelopmentTest.scala
+++ b/src/test/scala/DevelopmentTest.scala
@@ -127,7 +127,7 @@ class DevelopmentTest extends FunSpec {
 
       println(GameEngine.applyNormalCardHeuristicWithMoveSizeModifier(testMove2))
       println(GameEngine.applyNormalCardHeuristicWithMoveSizeModifier(threeMove))
-      println(GameEngine.wildCardUsagePenalty(threeMove))
+//      println(GameEngine.wildCardUsagePenalty(threeMove))
 
 
       println("--------------------------")
@@ -165,7 +165,7 @@ class DevelopmentTest extends FunSpec {
 
       println(GameEngine.applyNormalCardMoveHeuristic(single3, Move(List.empty), PlayerIndicators(aHand)))
       println(GameEngine.applyNormalCardHeuristicWithMoveSizeModifier(single3))
-      println(GameEngine.wildCardUsagePenalty(single3))
+//      println(GameEngine.wildCardUsagePenalty(single3))
 
       val move1 = Move(List(WildCard(THREE, Spade, 7), NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club), NormalCard(SEVEN, Heart)))
       val move2 = Move(List(WildCard(THREE, Diamond, 7), WildCard(THREE, Club, 7), WildCard(THREE, Heart, 7), NormalCard(SEVEN, Spade)))

--- a/src/test/scala/DevelopmentTest.scala
+++ b/src/test/scala/DevelopmentTest.scala
@@ -106,6 +106,13 @@ class DevelopmentTest extends FunSpec {
       println(GameUtilities.getValidMoves(allMovesWithThrees,
         Move(List(NormalCard(ACE, Diamond), NormalCard(ACE, Club)))))
 
+
+      val testMove = Move(List(
+        NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club), NormalCard(SEVEN, Heart), NormalCard(SEVEN, Spade)
+      ))
+      println("-------------")
+      println(testMove.highestCard)
+
     }
   }
 

--- a/src/test/scala/DevelopmentTest.scala
+++ b/src/test/scala/DevelopmentTest.scala
@@ -110,11 +110,65 @@ class DevelopmentTest extends FunSpec {
       val testMove = Move(List(WildCard(THREE, Diamond, 7), WildCard(THREE, Club, 7), WildCard(THREE, Heart, 7), WildCard(THREE, Spade, 7),
         NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club), NormalCard(SEVEN, Heart), NormalCard(SEVEN, Spade)
       ))
-      println("-------------")
+
+      val testMove2 = Move(List(
+        NormalCard(FOUR, Diamond), NormalCard(FOUR, Club), NormalCard(FOUR, Heart), NormalCard(FOUR, Spade)
+      ))
+
+      val threeMove = Move(List(WildCard(THREE, Spade, 14)))
+
+      println("--------------------------")
       println(testMove.highestCard)
       println(testMove.cards.forall(card => card match {case n: NormalCard => true; case _ => false}))
 
+
+      println(GameUtilities.getNumberOfWildCardsInMove(testMove))
+      println("--------------------------")
+
+      println(GameEngine.applyNormalCardHeuristicWithMoveSizeModifier(testMove2))
+      println(GameEngine.applyNormalCardHeuristicWithMoveSizeModifier(threeMove))
+      println(GameEngine.wildCardUsagePenalty(threeMove))
+
+
+      println("--------------------------")
+
+
     }
+
+    it("Observer game error secnario where 3-K was preferred over 10-10 for gamestate 9-9") {
+
+      val testMove = Move(List(WildCard(THREE, Diamond, 7), WildCard(THREE, Club, 7), WildCard(THREE, Heart, 7), WildCard(THREE, Spade, 7),
+        NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club), NormalCard(SEVEN, Heart), NormalCard(SEVEN, Spade)
+      ))
+      //<TEN,Diamond>, <TEN,Heart>
+      /*
+      List(<THREE,Heart(0)>, <SEVEN,Club>, <EIGHT,Club>, <EIGHT,Heart>, <TEN,Diamond>, <TEN,Heart>, <KING,Heart>)
+        List(<ACE,Diamond>, <TWO,Club>)
+       */
+      val observedHand = Hand(List(
+        WildCard(THREE, Heart), NormalCard(SEVEN, Club), NormalCard(EIGHT, Club), NormalCard(EIGHT, Heart),
+        NormalCard(TEN, Diamond), NormalCard(TEN, Heart), NormalCard(KING, Heart), NormalCard(ACE, Diamond),
+        SpecialCard(TWO, Club)
+      ))
+      val double10s = Move(List(NormalCard(TEN, Diamond), NormalCard(TEN, Heart)))
+      val otherMove = Move(List(WildCard(THREE, Heart, 13), NormalCard(KING, Heart)))
+      val gs = Move(List(NormalCard(NINE, Heart), NormalCard(NINE, Spade)))
+
+      println(GameEngine.getNormalCardMoveHeuristic(double10s, gs, PlayerIndicators(observedHand)))
+      println(GameEngine.getNormalCardMoveHeuristic(otherMove, gs, PlayerIndicators(observedHand)))
+
+      val single3 = Move(List(WildCard(THREE, Diamond, 14)))
+
+      println(testMove.numberOfNormalcards)
+
+      val aHand = Hand(List(WildCard(THREE, Diamond), SpecialCard(TWO, Diamond)))
+
+      println(GameEngine.getNormalCardMoveHeuristic(single3, Move(List.empty), PlayerIndicators(aHand)))
+      println(GameEngine.applyNormalCardHeuristicWithMoveSizeModifier(single3))
+      println(GameEngine.wildCardUsagePenalty(single3))
+
+    }
+
   }
 
 }

--- a/src/test/scala/DevelopmentTest.scala
+++ b/src/test/scala/DevelopmentTest.scala
@@ -101,9 +101,10 @@ class DevelopmentTest extends FunSpec {
       val threes = List(WildCard(THREE, Diamond), WildCard(THREE, Spade))
       val allMovesWithThrees = GameUtilities.addThreesToMoves(allMoves, threes)
 
-      println(GameUtilities.getValidMoves(allMovesWithThrees,
-        Move(List(NormalCard(FOUR, Diamond), NormalCard(FOUR, Club), NormalCard(FOUR, Heart), NormalCard(FOUR, Spade)))))
+      println(allMovesWithThrees)
 
+      println(GameUtilities.getValidMoves(allMovesWithThrees,
+        Move(List(NormalCard(ACE, Diamond), NormalCard(ACE, Club)))))
 
     }
   }

--- a/src/test/scala/DevelopmentTest.scala
+++ b/src/test/scala/DevelopmentTest.scala
@@ -1,6 +1,6 @@
 import game.FaceValue._
 import game.Suits._
-import game.{GameEngine, GameUtilities, Hand, Joker, Move, Moves, NormalCard, SpecialCard}
+import game._
 import org.scalatest.FunSpec
 import player.PlayerIndicators
 
@@ -84,6 +84,26 @@ class DevelopmentTest extends FunSpec {
       println("Next move is " + GameEngine.getNextMoveWrapper(validMoves, gameState)(playerIndicators))
 
       //      println(game.GameUtilities.getNextMoveV2(game.Moves(List(validMove1, validMove12, validMove3)), gameState))
+
+    }
+
+    it("is used for developing wildcard"){
+
+      val allMoves = Moves(List(
+        Move(List(NormalCard(SEVEN, Spade))),
+        Move(List(NormalCard(EIGHT, Heart), NormalCard(EIGHT, Spade))),
+        Move(List(NormalCard(NINE, Club), NormalCard(NINE, Heart), NormalCard(NINE, Spade))),
+        Move(List(NormalCard(TEN, Diamond), NormalCard(TEN, Club), NormalCard(TEN, Heart), NormalCard(TEN, Spade))),
+        Move(List(SpecialCard(TWO, Heart))),
+        Move(List(Joker))
+      ))
+
+      val threes = List(WildCard(THREE, Diamond), WildCard(THREE, Spade))
+      val allMovesWithThrees = GameUtilities.addThreesToMoves(allMoves, threes)
+
+      println(GameUtilities.getValidMoves(allMovesWithThrees,
+        Move(List(NormalCard(FOUR, Diamond), NormalCard(FOUR, Club), NormalCard(FOUR, Heart), NormalCard(FOUR, Spade)))))
+
 
     }
   }

--- a/src/test/scala/DevelopmentTest.scala
+++ b/src/test/scala/DevelopmentTest.scala
@@ -201,6 +201,8 @@ class DevelopmentTest extends FunSpec {
       // Here, K-diamond is preferred over playing the 3 - this is WRONG!
 //      val m1 =
 
+      // TODO - Make suitBurns not INFINITY- but a real high value
+
     }
 
   }

--- a/src/test/scala/DevelopmentTest.scala
+++ b/src/test/scala/DevelopmentTest.scala
@@ -167,6 +167,13 @@ class DevelopmentTest extends FunSpec {
       println(GameEngine.applyNormalCardHeuristicWithMoveSizeModifier(single3))
       println(GameEngine.wildCardUsagePenalty(single3))
 
+      val move1 = Move(List(WildCard(THREE, Spade, 7), NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club), NormalCard(SEVEN, Heart)))
+      val move2 = Move(List(WildCard(THREE, Diamond, 7), WildCard(THREE, Club, 7), WildCard(THREE, Heart, 7), NormalCard(SEVEN, Spade)))
+      //checkIfBetter
+      println(move1.highestCard)
+      println(move2.highestCard)
+      println(GameUtilities.checkIfBetter(move1, move2))
+
     }
 
   }

--- a/src/test/scala/DevelopmentTest.scala
+++ b/src/test/scala/DevelopmentTest.scala
@@ -1,6 +1,7 @@
 import game.FaceValue._
 import game.Suits._
 import game._
+import utils.Consants._
 import org.scalatest.FunSpec
 import player.PlayerIndicators
 
@@ -201,7 +202,68 @@ class DevelopmentTest extends FunSpec {
       // Here, K-diamond is preferred over playing the 3 - this is WRONG!
 //      val m1 =
 
-      // TODO - Make suitBurns not INFINITY- but a real high value
+
+    }
+
+    it("Is anoter real scenario") {
+
+      val gameState = Move(List(JACK_Diamond, JACK_Club, JACK_Spade))
+      val pHand = Hand(List(
+        WildCard(THREE, Club), WildCard(THREE, Spade),
+        NormalCard(FOUR, Diamond), NormalCard(FOUR, Heart),
+        NormalCard(FIVE, Club), NormalCard(SIX, Club),
+        NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club), NormalCard(SEVEN, Spade),
+        NormalCard(NINE, Diamond), NormalCard(QUEEN, Diamond),
+        NormalCard(ACE, Diamond), NormalCard(ACE, Spade)
+      ))
+
+      val m1 = Move(List(THREE_Club(14), ACE_Diamond, ACE_Spade))
+      val m2 = Move(List(THREE_Club(12), THREE_Spade(12), QUEEN_Diamond))
+
+      val pi = PlayerIndicators(pHand)
+
+      println("Wildcardpenalty modifier is " + pi.wildCardPenaltyModifier)
+
+
+      println(
+        ((0.4 * (1/(m1.moveFaceValue - WildCard(THREE, Diamond).intValue)))
+          + (0.2 * (1/ m1.parity))
+          + (0.4 * 1 / (maxMoveSize -  GameUtilities.getNumberOfWildCardsInMove(m1))))
+      )
+
+      println("m2 heuristic : " + GameEngine.applyNormalCardMoveHeuristic(m1, gameState, pi).likelihood )
+      println("wilcard penal m1 :  "+GameEngine.wildCardUsagePenalty(m1, pi.wildCardPenaltyModifier))
+      println("-----------")
+      println("m2 heuristic : " + GameEngine.applyNormalCardMoveHeuristic(m2, gameState, pi).likelihood )
+      println(
+        ((0.4 * (1/(m2.moveFaceValue - WildCard(THREE, Diamond).intValue)))
+          + (0.2 * (1/m2.parity))
+          + (0.4 * 1 / (maxMoveSize - GameUtilities.getNumberOfWildCardsInMove(m2))))
+      )
+
+      println("wilcard penal m2 "+ GameEngine.wildCardUsagePenalty(m2, pi.wildCardPenaltyModifier))
+
+    }
+
+
+    it("Is another scenario") {
+
+      val hand = Hand(List(
+        THREE_Diamond, THREE_Heart, FIVE_Diamond, JACK_Heart, QUEEN_Diamond, TWO_Heart
+      ))
+
+      val m1 = Move(List(THREE_Diamond(5), FIVE_Diamond))
+      val m2 = Move(List(THREE_Diamond(5), THREE_Heart(5), FIVE_Diamond))
+      val pi = PlayerIndicators(hand)
+      val gameState = Move(List.empty)
+
+      println(m1)
+      println(GameEngine.applyNormalCardMoveHeuristic(m1, gameState, pi).likelihood + GameEngine.wildCardUsagePenalty(m1, pi.wildCardPenaltyModifier))
+      println(GameEngine.wildCardUsagePenalty(m1, pi.wildCardPenaltyModifier))
+
+      println(m2)
+      println(GameEngine.applyNormalCardMoveHeuristic(m2, gameState, pi).likelihood + GameEngine.wildCardUsagePenalty(m2, pi.wildCardPenaltyModifier))
+      println(GameEngine.wildCardUsagePenalty(m2, pi.wildCardPenaltyModifier))
 
     }
 

--- a/src/test/scala/DevelopmentTest.scala
+++ b/src/test/scala/DevelopmentTest.scala
@@ -175,6 +175,20 @@ class DevelopmentTest extends FunSpec {
       println(GameUtilities.checkIfBetter(move1, move2))
       print(GameUtilities.getNextGameState(move1, Some(move2)))
 
+
+
+    }
+
+    it("is a new test") {
+      val m = Move(List(WildCard(THREE, Diamond), WildCard(THREE, Spade, 8), NormalCard(SEVEN, Club)))
+      println(m.highestCard)
+
+      //checkIfBetter
+      val m1 = Move(List(WildCard(THREE, Diamond, 7), NormalCard(SEVEN, Club)))
+      val m2 = Move(List(WildCard(THREE, Club, 14), WildCard(THREE, Spade, 7)))
+
+      println(GameUtilities.checkIfBetter(m1, m2))
+
     }
 
   }

--- a/src/test/scala/GameEngineTest.scala
+++ b/src/test/scala/GameEngineTest.scala
@@ -564,7 +564,7 @@ class GameEngineTest extends FunSpec {
       describe("When gameState is empty") {
         it("Should return playerModifier.specialCardModifier or 0") {
           val result = GameEngine.applySpecialCardMoveHeuristic(validMove, Move(List.empty), playerIndicators)
-          assert(result == playerIndicators.specialCardModifier || result == 0)
+          assert(result.likelihood == playerIndicators.specialCardModifier || result.likelihood == 0)
         }
       }
 
@@ -572,8 +572,8 @@ class GameEngineTest extends FunSpec {
         it("Should return playerModifier.specialCardModifier or 0") {
           val result = GameEngine.applySpecialCardMoveHeuristic(validMove, Move(List(NormalCard(ACE, Heart))), playerIndicators)
           val result2 = GameEngine.applySpecialCardMoveHeuristic(validMove, Move(List(NormalCard(ACE, Heart), NormalCard(ACE, Spade))), playerIndicators)
-          assert(result == playerIndicators.specialCardModifier || result == 0)
-          assert(result2 == playerIndicators.specialCardModifier || result2 == 0)
+          assert(result.likelihood == playerIndicators.specialCardModifier || result.likelihood == 0)
+          assert(result2.likelihood == playerIndicators.specialCardModifier || result2.likelihood == 0)
         }
       }
 
@@ -583,8 +583,8 @@ class GameEngineTest extends FunSpec {
             Move(List(NormalCard(ACE, Club), NormalCard(ACE, Heart), NormalCard(ACE, Spade))), playerIndicators)
           val result2 = GameEngine.applySpecialCardMoveHeuristic(validMove,
             Move(List(NormalCard(ACE, Diamond), NormalCard(ACE, Club), NormalCard(ACE, Heart), NormalCard(ACE, Spade))), playerIndicators)
-          assert(result == playerIndicators.specialCardModifier || result == 0)
-          assert(result2 == playerIndicators.specialCardModifier || result2 == 0)
+          assert(result.likelihood == playerIndicators.specialCardModifier || result.likelihood == 0)
+          assert(result2.likelihood == playerIndicators.specialCardModifier || result2.likelihood == 0)
         }
       }
 
@@ -600,14 +600,14 @@ class GameEngineTest extends FunSpec {
         describe("When gameState is empty") {
           it("Should return playerModifier.specialCardModifier or 0") {
             val result = GameEngine.applySpecialCardMoveHeuristic(single2, Move(List.empty), playerIndicators)
-            assert(result == playerIndicators.specialCardModifier || result == 0)
+            assert(result.likelihood == playerIndicators.specialCardModifier || result.likelihood == 0)
           }
         }
 
         describe("When a single 2 is played on top of a single NormalCard") {
           it("Should return playerModifier.specialCardModifier or 0") {
             val result = GameEngine.applySpecialCardMoveHeuristic(single2, Move(List(NormalCard(ACE, Diamond))), playerIndicators)
-            assert(result == playerIndicators.specialCardModifier || result == 0)
+            assert(result.likelihood == playerIndicators.specialCardModifier || result.likelihood == 0)
           }
         }
 
@@ -615,7 +615,7 @@ class GameEngineTest extends FunSpec {
           it("Should return playerModifier.specialCardModifier or 0") {
             val result = GameEngine.applySpecialCardMoveHeuristic(single2,
               Move(List(NormalCard(ACE, Diamond), NormalCard(ACE, Spade))), playerIndicators)
-            assert(result == playerIndicators.specialCardModifier || result == 0)
+            assert(result.likelihood == playerIndicators.specialCardModifier || result.likelihood == 0)
           }
         }
 
@@ -623,14 +623,14 @@ class GameEngineTest extends FunSpec {
           describe("When the 2 being played is one-suit-away from the 2 on top") {
             it("Should return playerModifier.specialCardModifier") {
               val result = GameEngine.applySpecialCardMoveHeuristic(single2, Move(List(SpecialCard(TWO, Club))), playerIndicators)
-              assert(result == playerIndicators.specialCardModifier)
+              assert(result.likelihood == playerIndicators.specialCardModifier)
             }
           }
 
           describe("When the 2 being played is not one-suit-away from the 2 on top") {
             it("Should return playerModifier.specialCardModifier or 0") {
               val result = GameEngine.applySpecialCardMoveHeuristic(single2, Move(List(SpecialCard(TWO, Diamond))), playerIndicators)
-              assert(result == playerIndicators.specialCardModifier || result == 0)
+              assert(result.likelihood == playerIndicators.specialCardModifier || result.likelihood == 0)
             }
           }
         }
@@ -642,7 +642,7 @@ class GameEngineTest extends FunSpec {
           it("Should return playerModifier.specialCardModifier or 0") {
             val result = GameEngine.applySpecialCardMoveHeuristic(double2,
               Move(List(NormalCard(EIGHT, Diamond), NormalCard(EIGHT, Club), NormalCard(EIGHT, Heart))), playerIndicators)
-            assert(result == playerIndicators.specialCardModifier || result == 0)
+            assert(result.likelihood == playerIndicators.specialCardModifier || result.likelihood == 0)
           }
         }
 
@@ -650,7 +650,7 @@ class GameEngineTest extends FunSpec {
           it("Should return playerModifier.specialCardModifier or 0") {
             val result = GameEngine.applySpecialCardMoveHeuristic(triple2,
               Move(List(NormalCard(EIGHT, Diamond), NormalCard(EIGHT, Club), NormalCard(EIGHT, Heart), NormalCard(EIGHT, Spade))), playerIndicators)
-            assert(result == playerIndicators.specialCardModifier || result == 0)
+            assert(result.likelihood == playerIndicators.specialCardModifier || result.likelihood == 0)
           }
         }
 
@@ -658,7 +658,7 @@ class GameEngineTest extends FunSpec {
           it("should not care about off-by-one suit-burn preferences since it is still an expensive move and return 0/modifier value") {
             val result = GameEngine.applySpecialCardMoveHeuristic(double2,
               Move(List(SpecialCard(TWO, Diamond), SpecialCard(TWO, Club))), playerIndicators)
-            assert(result == playerIndicators.specialCardModifier || result == 0)
+            assert(result.likelihood == playerIndicators.specialCardModifier || result.likelihood == 0)
           }
         }
 
@@ -718,70 +718,70 @@ class GameEngineTest extends FunSpec {
     describe("When it is a single in a move and a single in the Hand") {
       it("Should not be penalized") {
         assert(GameEngine.applyNormalCardHeuristicWithPenaltyForBreakingSets(single7, gameState, 1) ===
-          ((0.22d * (1d / (single7.moveFaceValue - gameState.moveFaceValue)))) + (0.78d * 1 / (1 - single7.parity + 1)))
+          ((0.22d * (1d / (single7.moveFaceValue - gameState.moveFaceValue + 1)))) + (0.78d * 1 / (1 - single7.parity + 1)))
       }
     }
 
     describe("When it is a single in a move and a double in the Hand"){
       it("Should be penalized"){
         assert(GameEngine.applyNormalCardHeuristicWithPenaltyForBreakingSets(single7, gameState, 2) ===
-          ((0.22d * (1d/(single7.moveFaceValue - gameState.moveFaceValue)))) + (0.78d * 1/(2 - single7.parity + 1)))
+          ((0.22d * (1d/(single7.moveFaceValue - gameState.moveFaceValue + 1)))) + (0.78d * 1/(2 - single7.parity + 1)))
       }
      }
 
     describe("When it is a single in a move and a triple in the Hand"){
       it("Should be penalized"){
         assert(GameEngine.applyNormalCardHeuristicWithPenaltyForBreakingSets(single7, gameState, 3) ===
-          ((0.22d * (1d/(single7.moveFaceValue - gameState.moveFaceValue)))) + (0.78d * 1/(3 - single7.parity + 1)))
+          ((0.22d * (1d/(single7.moveFaceValue - gameState.moveFaceValue + 1)))) + (0.78d * 1/(3 - single7.parity + 1)))
       }
     }
 
     describe("When it is a single in a move and a quadruple in the Hand"){
       it("Should be penalized"){
         assert(GameEngine.applyNormalCardHeuristicWithPenaltyForBreakingSets(single7, gameState, 4) ===
-          ((0.22d * (1d/(single7.moveFaceValue - gameState.moveFaceValue)))) + (0.78d * 1/(4 - single7.parity + 1)))
+          ((0.22d * (1d/(single7.moveFaceValue - gameState.moveFaceValue + 1)))) + (0.78d * 1/(4 - single7.parity + 1)))
       }
     }
 
     describe("When it is a double in a move and a triple in the Hand"){
       it("Should be penalized"){
         assert(GameEngine.applyNormalCardHeuristicWithPenaltyForBreakingSets(double7s, gameState, 3) ===
-          ((0.22d * (1d/(double7s.moveFaceValue - gameState.moveFaceValue)))) + (0.78d * 1/(3 - double7s.parity + 1)))
+          ((0.22d * (1d/(double7s.moveFaceValue - gameState.moveFaceValue + 1)))) + (0.78d * 1/(3 - double7s.parity + 1)))
       }
     }
 
     describe("When it is a double in a move and a quadruple in the Hand"){
       it("Should be penalized"){
         assert(GameEngine.applyNormalCardHeuristicWithPenaltyForBreakingSets(double7s, gameState, 4) ===
-          ((0.22d * (1d/(double7s.moveFaceValue - gameState.moveFaceValue)))) + (0.78d * 1/(4 - double7s.parity + 1)))
+          ((0.22d * (1d/(double7s.moveFaceValue - gameState.moveFaceValue + 1)))) + (0.78d * 1/(4 - double7s.parity + 1)))
       }
     }
 
     describe("When it is a triple in a move and a quadruple in the Hand"){
       it("Should be penalized"){
         assert(GameEngine.applyNormalCardHeuristicWithPenaltyForBreakingSets(triple7s, gameState, 4) ===
-          ((0.22d * (1d/(triple7s.moveFaceValue - gameState.moveFaceValue)))) + (0.78d * 1/(4 - triple7s.parity + 1)))
+          ((0.22d * (1d/(triple7s.moveFaceValue - gameState.moveFaceValue + 1)))) + (0.78d * 1/(4 - triple7s.parity + 1)))
       }
     }
 
     describe("When it is a quadruple in a move and a quadruple in the Hand"){
       it("Should not be penalized"){
         assert(GameEngine.applyNormalCardHeuristicWithPenaltyForBreakingSets(quad7s, gameState, 4) ===
-          ((0.22d * (1d/(quad7s.moveFaceValue - gameState.moveFaceValue)))) + (0.78d * 1/(4 - quad7s.parity + 1)))
+          ((0.22d * (1d/(quad7s.moveFaceValue - gameState.moveFaceValue + 1)))) + (0.78d * 1/(4 - quad7s.parity + 1)))
       }
     }
 
     describe("When it is a triple in a move and a triple in the Hand"){
       it("Should not be penalized"){
         assert(GameEngine.applyNormalCardHeuristicWithPenaltyForBreakingSets(triple7s, gameState, 3) ===
-          ((0.22d * (1d/(triple7s.moveFaceValue - gameState.moveFaceValue)))) + (0.78d * 1/(3 - triple7s.parity + 1)))
+          ((0.22d * (1d/(triple7s.moveFaceValue - gameState.moveFaceValue + 1)))) + (0.78d * 1/(3 - triple7s.parity + 1)))
       }
     }
 
     describe("When it is a double in a move and a double in the Hand"){
       it("Should not be penalized"){
         assert(GameEngine.applyNormalCardHeuristicWithPenaltyForBreakingSets(double7s, gameState, 2) ===
-          ((0.22d * (1d/(double7s.moveFaceValue - gameState.moveFaceValue)))) + (0.78d * 1/(2 - double7s.parity + 1)))
+          ((0.22d * (1d/(double7s.moveFaceValue - gameState.moveFaceValue + 1)))) + (0.78d * 1/(2 - double7s.parity + 1)))
       }
     }
 

--- a/src/test/scala/GameEngineTest.scala
+++ b/src/test/scala/GameEngineTest.scala
@@ -574,27 +574,23 @@ class GameEngineTest extends FunSpec {
   describe("tests for getSpecialCardMoveHeuristic()") {
 
     val hand = Hand(List(
-      NormalCard(SEVEN, Heart),
-      NormalCard(NINE, Diamond),
-      NormalCard(JACK, Club),
-      NormalCard(JACK, Diamond),
-      NormalCard(ACE, Spade),
-      SpecialCard(TWO, Diamond),
-      SpecialCard(TWO, Club),
-      SpecialCard(TWO, Heart),
-      Joker,
+      SEVEN_Heart,
+      NINE_Diamond,
+      JACK_Club, JACK_Diamond,
+      ACE_Spade,
+      TWO_Diamond, TWO_Club, TWO_Heart, Joker
     ))
 
     val playerIndicators = PlayerIndicators(hand)
 
     describe("Throws exception when") {
-      it("Move involves a NormalCard") {
-        assertThrows[IllegalHeuristicFunctionException](GameEngine.applySpecialCardMoveHeuristic(Move(List(NormalCard(EIGHT, Heart))), Move(List.empty)))
+      it("Move involves a single NormalCard") {
+        assertThrows[IllegalHeuristicFunctionException](GameEngine.applySpecialCardMoveHeuristic(Move(List(EIGHT_Heart)), Move(List.empty)))
       }
 
-      it("Move involves a list of NormalCard"){
+      it("Move involves multiple of NormalCard"){
         assertThrows[IllegalHeuristicFunctionException](GameEngine.applySpecialCardMoveHeuristic(
-          Move(List(NormalCard(NINE, Club), NormalCard(NINE, Heart), NormalCard(NINE, Spade))), Move(List.empty)))
+          Move(List(NINE_Club, NINE_Heart, NINE_Spade)), Move(List.empty)))
       }
     }
 
@@ -611,8 +607,8 @@ class GameEngineTest extends FunSpec {
 
       describe("When gameState is a single or a double") {
         it("Should return playerModifier.specialCardModifier or 0") {
-          val result = GameEngine.applySpecialCardMoveHeuristic(validMove, Move(List(NormalCard(ACE, Heart))), playerIndicators)
-          val result2 = GameEngine.applySpecialCardMoveHeuristic(validMove, Move(List(NormalCard(ACE, Heart), NormalCard(ACE, Spade))), playerIndicators)
+          val result = GameEngine.applySpecialCardMoveHeuristic(validMove, Move(List(ACE_Heart)), playerIndicators)
+          val result2 = GameEngine.applySpecialCardMoveHeuristic(validMove, Move(List(ACE_Heart, ACE_Spade)), playerIndicators)
           assert(result.likelihood == playerIndicators.specialCardModifier || result.likelihood == 0)
           assert(result2.likelihood == playerIndicators.specialCardModifier || result2.likelihood == 0)
         }
@@ -621,9 +617,9 @@ class GameEngineTest extends FunSpec {
       describe("When gameState is a triple or higher") {
         it("Should return playerModifier.specialCardModifier or 0") {
           val result = GameEngine.applySpecialCardMoveHeuristic(validMove,
-            Move(List(NormalCard(ACE, Club), NormalCard(ACE, Heart), NormalCard(ACE, Spade))), playerIndicators)
+            Move(List(ACE_Club, ACE_Heart, ACE_Spade)), playerIndicators)
           val result2 = GameEngine.applySpecialCardMoveHeuristic(validMove,
-            Move(List(NormalCard(ACE, Diamond), NormalCard(ACE, Club), NormalCard(ACE, Heart), NormalCard(ACE, Spade))), playerIndicators)
+            Move(List(ACE_Diamond , ACE_Club, ACE_Heart, ACE_Spade)), playerIndicators)
           assert(result.likelihood == playerIndicators.specialCardModifier || result.likelihood == 0)
           assert(result2.likelihood == playerIndicators.specialCardModifier || result2.likelihood == 0)
         }
@@ -633,9 +629,9 @@ class GameEngineTest extends FunSpec {
 
     describe("When validMove comprises of a single/multiple 2s") {
 
-      val single2 = Move(List(SpecialCard(TWO, Heart)))
-      val double2 = Move(List(SpecialCard(TWO, Heart), SpecialCard(TWO, Spade)))
-      val triple2 = Move(List(SpecialCard(TWO, Diamond), SpecialCard(TWO, Club), SpecialCard(TWO, Heart)))
+      val single2 = Move(List(TWO_Heart))
+      val double2 = Move(List(TWO_Heart, TWO_Spade))
+      val triple2 = Move(List(TWO_Diamond, TWO_Club, TWO_Heart))
 
       describe("When validMove consists of a single 2") {
         describe("When gameState is empty") {
@@ -647,7 +643,7 @@ class GameEngineTest extends FunSpec {
 
         describe("When a single 2 is played on top of a single NormalCard") {
           it("Should return playerModifier.specialCardModifier or 0") {
-            val result = GameEngine.applySpecialCardMoveHeuristic(single2, Move(List(NormalCard(ACE, Diamond))), playerIndicators)
+            val result = GameEngine.applySpecialCardMoveHeuristic(single2, Move(List(ACE_Diamond)), playerIndicators)
             assert(result.likelihood == playerIndicators.specialCardModifier || result.likelihood == 0)
           }
         }
@@ -655,7 +651,7 @@ class GameEngineTest extends FunSpec {
         describe("When a single 2 is played on top of a double NormalCard"){
           it("Should return playerModifier.specialCardModifier or 0") {
             val result = GameEngine.applySpecialCardMoveHeuristic(single2,
-              Move(List(NormalCard(ACE, Diamond), NormalCard(ACE, Spade))), playerIndicators)
+              Move(List(ACE_Diamond, ACE_Spade)), playerIndicators)
             assert(result.likelihood == playerIndicators.specialCardModifier || result.likelihood == 0)
           }
         }
@@ -663,14 +659,14 @@ class GameEngineTest extends FunSpec {
         describe("When a single 2 is played on top of another single 2") {
           describe("When the 2 being played is one-suit-away from the 2 on top") {
             it("Should return playerModifier.specialCardModifier") {
-              val result = GameEngine.applySpecialCardMoveHeuristic(single2, Move(List(SpecialCard(TWO, Club))), playerIndicators)
+              val result = GameEngine.applySpecialCardMoveHeuristic(single2, Move(List(TWO_Club)), playerIndicators)
               assert(result.likelihood == playerIndicators.specialCardModifier)
             }
           }
 
           describe("When the 2 being played is not one-suit-away from the 2 on top") {
             it("Should return playerModifier.specialCardModifier or 0") {
-              val result = GameEngine.applySpecialCardMoveHeuristic(single2, Move(List(SpecialCard(TWO, Diamond))), playerIndicators)
+              val result = GameEngine.applySpecialCardMoveHeuristic(single2, Move(List(TWO_Diamond)), playerIndicators)
               assert(result.likelihood == playerIndicators.specialCardModifier || result.likelihood == 0)
             }
           }
@@ -682,7 +678,7 @@ class GameEngineTest extends FunSpec {
         describe("When two 2s are being played") {
           it("Should return playerModifier.specialCardModifier or 0") {
             val result = GameEngine.applySpecialCardMoveHeuristic(double2,
-              Move(List(NormalCard(EIGHT, Diamond), NormalCard(EIGHT, Club), NormalCard(EIGHT, Heart))), playerIndicators)
+              Move(List(EIGHT_Diamond, EIGHT_Club, EIGHT_Heart)), playerIndicators)
             assert(result.likelihood == playerIndicators.specialCardModifier || result.likelihood == 0)
           }
         }
@@ -690,7 +686,7 @@ class GameEngineTest extends FunSpec {
         describe("When three 2s are being played") {
           it("Should return playerModifier.specialCardModifier or 0") {
             val result = GameEngine.applySpecialCardMoveHeuristic(triple2,
-              Move(List(NormalCard(EIGHT, Diamond), NormalCard(EIGHT, Club), NormalCard(EIGHT, Heart), NormalCard(EIGHT, Spade))), playerIndicators)
+              Move(List(EIGHT_Diamond, EIGHT_Club, EIGHT_Heart, EIGHT_Spade)), playerIndicators)
             assert(result.likelihood == playerIndicators.specialCardModifier || result.likelihood == 0)
           }
         }
@@ -698,7 +694,7 @@ class GameEngineTest extends FunSpec {
         describe("When two 2s are being played on top of existing two 2s"){
           it("should not care about off-by-one suit-burn preferences since it is still an expensive move and return 0/modifier value") {
             val result = GameEngine.applySpecialCardMoveHeuristic(double2,
-              Move(List(SpecialCard(TWO, Diamond), SpecialCard(TWO, Club))), playerIndicators)
+              Move(List(TWO_Diamond, TWO_Club)), playerIndicators)
             assert(result.likelihood == playerIndicators.specialCardModifier || result.likelihood == 0)
           }
         }
@@ -711,14 +707,14 @@ class GameEngineTest extends FunSpec {
   describe("tests for applyNormalCardHeuristicWithMoveSizeModifier()") {
     describe("When multiple validMoves exist when gameState is Empty") {
       it("Should return the highest value to the most desirable move of the lot") {
-        val move1 = Move(List(NormalCard(FOUR, Spade)))
-        val move2 = Move(List(NormalCard(FOUR, Heart), NormalCard(FOUR, Spade)))
-        val move3 = Move(List(NormalCard(FOUR, Club), NormalCard(FOUR, Heart), NormalCard(FOUR, Spade)))
-        val move4 = Move(List(NormalCard(FOUR, Diamond), NormalCard(FOUR, Club), NormalCard(FOUR, Heart), NormalCard(FOUR, Spade)))
-        val move5 = Move(List(NormalCard(QUEEN, Diamond), NormalCard(QUEEN, Club), NormalCard(QUEEN, Heart), NormalCard(QUEEN, Spade)))
-        val move6 = Move(List(NormalCard(QUEEN, Club), NormalCard(QUEEN, Heart), NormalCard(QUEEN, Spade)))
-        val move7 = Move(List(NormalCard(QUEEN, Heart), NormalCard(QUEEN, Spade)))
-        val move8 = Move(List( NormalCard(QUEEN, Spade)))
+        val move1 = Move(List(FOUR_Spade))
+        val move2 = Move(List(FOUR_Heart, FOUR_Spade))
+        val move3 = Move(List(FOUR_Club, FOUR_Heart, FOUR_Spade))
+        val move4 = Move(List(FOUR_Diamond, FOUR_Club, FOUR_Heart, FOUR_Spade))
+        val move5 = Move(List(QUEEN_Diamond, QUEEN_Club, QUEEN_Heart, QUEEN_Spade))
+        val move6 = Move(List(QUEEN_Club, QUEEN_Heart, QUEEN_Spade))
+        val move7 = Move(List(QUEEN_Heart, QUEEN_Spade))
+        val move8 = Move(List(QUEEN_Spade))
 
         val r1 = GameEngine.applyNormalCardHeuristicWithMoveSizeModifier(move1)
         val r2 = GameEngine.applyNormalCardHeuristicWithMoveSizeModifier(move2)
@@ -742,15 +738,15 @@ class GameEngineTest extends FunSpec {
   }
 
   describe("tests for applyNormalCardHeuristicWithPenaltyForBreakingSets()") {
-    val single7 = Move(List(NormalCard(SEVEN, Heart)))
-    val double7s = Move(List(NormalCard(SEVEN, Heart), NormalCard(SEVEN, Spade)))
-    val triple7s = Move(List(NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club), NormalCard(SEVEN, Heart)))
-    val quad7s = Move(List(NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club), NormalCard(SEVEN, Heart), NormalCard(SEVEN, Spade)))
-    val gameState = Move(List(NormalCard(SIX, Heart)))
+    val single7 = Move(List(SEVEN_Heart))
+    val double7s = Move(List(SEVEN_Heart, SEVEN_Spade))
+    val triple7s = Move(List(SEVEN_Diamond, SEVEN_Club, SEVEN_Heart))
+    val quad7s = Move(List(SEVEN_Diamond, SEVEN_Club, SEVEN_Heart, SEVEN_Spade))
+    val gameState = Move(List(SIX_Heart))
 
     describe("When the moveFaceValue and the gameStateFaceValue are the same (suit-burn") {
       it("Should return 1") {
-        assert(GameEngine.applyNormalCardHeuristicWithPenaltyForBreakingSets(single7, Move(List(NormalCard(SEVEN, Club))), 1) == 1.0d)
+        assert(GameEngine.applyNormalCardHeuristicWithPenaltyForBreakingSets(single7, Move(List(SEVEN_Club)), 1) == 1.0d)
         assert(GameEngine.applyNormalCardHeuristicWithPenaltyForBreakingSets(double7s,
           Move(List(NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club))), 2) == 1.0d)
       }
@@ -824,6 +820,27 @@ class GameEngineTest extends FunSpec {
         assert(GameEngine.applyNormalCardHeuristicWithPenaltyForBreakingSets(double7s, gameState, 2) ===
           ((0.22d * (1d/(double7s.moveFaceValue - gameState.moveFaceValue + 1)))) + (0.78d * 1/(2 - double7s.parity + 1)))
       }
+    }
+
+    describe("When the move involves WildCards in it") {
+     it("Should not be penalized when all cards of its kind are used"){
+       val wildcardDouble7s = Move(List(THREE_Heart(7), SEVEN_Spade))
+       assert(GameEngine.applyNormalCardHeuristicWithPenaltyForBreakingSets(wildcardDouble7s, gameState, 1) ===
+         ((0.22d * (1d/(double7s.moveFaceValue - gameState.moveFaceValue + 1)))) + (0.78d * 1/(1 - wildcardDouble7s.numberOfNormalcards + 1)))
+     }
+
+      it("Should be penalized when not all cards of its kind are used") {
+        val wildcardQuad7s = Move(List(THREE_Diamond(7), THREE_Club(7), THREE_Heart(7), SEVEN_Spade))
+        assert(GameEngine.applyNormalCardHeuristicWithPenaltyForBreakingSets(wildcardQuad7s, gameState, 3) ===
+          ((0.22d * (1d/(double7s.moveFaceValue - gameState.moveFaceValue + 1)))) + (0.78d * 1/(3 - wildcardQuad7s.numberOfNormalcards + 1)))
+      }
+
+      it("Should not be penalized when all cards involved are wildcards") {
+        val wildcardQuad7s = Move(List(THREE_Diamond(7), THREE_Club(7), THREE_Heart(7), THREE_Spade(7)))
+        assert(GameEngine.applyNormalCardHeuristicWithPenaltyForBreakingSets(wildcardQuad7s, gameState, 0) ===
+          ((0.22d * (1d/(double7s.moveFaceValue - gameState.moveFaceValue + 1)))) + (0.78d))
+      }
+
     }
 
   }

--- a/src/test/scala/GameEngineTest.scala
+++ b/src/test/scala/GameEngineTest.scala
@@ -1,11 +1,12 @@
 import game.FaceValue._
 import game.GameEngine.IllegalHeuristicFunctionException
-import game.{GameEngine, GameUtilities, Hand, Joker, Move, Moves, NormalCard, SpecialCard}
+import game.{Card, GameEngine, GameUtilities, Hand, Joker, Move, Moves, NormalCard, SpecialCard, WildCard}
 import game.Suits._
 import org.scalactic.{Equality, TolerantNumerics}
 import org.scalatest.FunSpec
 import player.PlayerIndicators
 import utils.Consants
+import utils.Consants._
 
 class GameEngineTest extends FunSpec {
 
@@ -223,13 +224,12 @@ class GameEngineTest extends FunSpec {
       describe("When gameState is a low single") {
         it("Should pick the lowest single that minimizes the delta in faceValue") {
           val gameState = Move(List(NormalCard(FIVE, Club)))
-          val allValidMoves = GameUtilities.getValidMoves(GameUtilities.getAllMoves(sampleHand.listOfSimilarCards), gameState)
           assert(GameEngine.getNextMove(allSingles, gameState)
-          (GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(allSingles.moves.head))
+          (GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(Move(List(SEVEN_Diamond))))
         }
 
         it("Should pick a higher single without breaking a set than a lower single that involves breaking a set ") {
-          val gameState = Move(List(NormalCard(THREE, Diamond)))
+          val gameState = Move(List(FOUR_Diamond))
           val allValidMoves = GameUtilities.getValidMoves(GameUtilities.getAllMoves(sampleHand.listOfSimilarCards), gameState)
           assert(GameEngine.getNextMove(allValidMoves, gameState)
           (GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(Move(List(NormalCard(SEVEN, Diamond)))))
@@ -239,7 +239,7 @@ class GameEngineTest extends FunSpec {
 
       describe("When gameState is a low double") {
         it("Should pick a higher double without breaking a set than a lower double that involves breaking a set ") {
-          val gameState = Move(List(NormalCard(THREE, Diamond), NormalCard(THREE, Club)))
+          val gameState = Move(List(FOUR_Diamond, FOUR_Club))
           val allValidMoves = GameUtilities.getValidMoves(GameUtilities.getAllMoves(sampleHand.listOfSimilarCards), gameState)
           assert(GameEngine.getNextMove(allValidMoves, gameState)
           (GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(Move(List(NormalCard(SIX, Diamond), NormalCard(SIX, Club)))))
@@ -248,11 +248,10 @@ class GameEngineTest extends FunSpec {
 
       describe("When gameState is a low triple") {
         it("Should pick a higher triple without breaking a set than a lower triple that involves breaking a set ") {
-          val gameState = Move(List(NormalCard(THREE, Diamond), NormalCard(THREE, Club), NormalCard(THREE, Heart)))
+          val gameState = Move(List(FOUR_Diamond, FOUR_Club, FOUR_Heart))
           val allValidMoves = GameUtilities.getValidMoves(GameUtilities.getAllMoves(sampleHand.listOfSimilarCards), gameState)
           assert(GameEngine.getNextMove(allValidMoves, gameState)
-          (GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(Move(List(NormalCard(FIVE, Diamond),
-            NormalCard(FIVE, Club), NormalCard(FIVE, Heart)))))
+          (GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(Move(List(FIVE_Diamond, FIVE_Club, FIVE_Heart))))
         }
       }
 
@@ -364,7 +363,11 @@ class GameEngineTest extends FunSpec {
         ))
         val gameState = Move(List.empty)
         val result = GameEngine.getNextMoveWrapper(validMoves, gameState)(playerInd)
-        assert(result.contains(Move(List(SpecialCard(TWO, Diamond)))) || result.isEmpty)
+        assert(result.isEmpty || result.get.cards.map{
+        case s: SpecialCard => true
+        case n: NormalCard => false
+        case w: WildCard => false
+        case j: Card => true}.forall(x => x))
       }
     }
 

--- a/src/test/scala/GameEngineTest.scala
+++ b/src/test/scala/GameEngineTest.scala
@@ -707,8 +707,8 @@ class GameEngineTest extends FunSpec {
     describe("When the moveFaceValue and the gameStateFaceValue are the same (suit-burn") {
       it("Should return 1") {
         assert(GameEngine.applyNormalCardHeuristicWithPenaltyForBreakingSets(single7, Move(List(NormalCard(SEVEN, Club))), 1) == 1.0d)
-        assert(GameEngine.applyNormalCardHeuristicWithPenaltyForBreakingSets(single7,
-          Move(List(NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club))), 1).isInfinite)
+        assert(GameEngine.applyNormalCardHeuristicWithPenaltyForBreakingSets(double7s,
+          Move(List(NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club))), 2) == 1.0d)
       }
     }
 

--- a/src/test/scala/GameEngineTest.scala
+++ b/src/test/scala/GameEngineTest.scala
@@ -18,7 +18,7 @@ class GameEngineTest extends FunSpec {
       it("Should return an None") {
         val playerIndicators: PlayerIndicators = PlayerIndicators(Hand(List.empty))
         assert(GameEngine.getNextMove(Moves(List.empty), Move(List.empty))
-        (GameEngine.getNormalCardMoveHeuristic, playerIndicators).isEmpty)
+        (GameEngine.applyNormalCardMoveHeuristic, playerIndicators).isEmpty)
       }
     }
 
@@ -26,7 +26,7 @@ class GameEngineTest extends FunSpec {
       it("Should return the validMove") {
         val gameState = Move(List(NormalCard(JACK, Heart)))
         val validMoves = Moves(List(Move(List(NormalCard(QUEEN, Diamond)))))
-        assert(GameEngine.getNextMove(validMoves, gameState)(GameEngine.getNormalCardMoveHeuristic, PlayerIndicators(Hand(List(NormalCard(QUEEN, Diamond)))))
+        assert(GameEngine.getNextMove(validMoves, gameState)(GameEngine.applyNormalCardMoveHeuristic, PlayerIndicators(Hand(List(NormalCard(QUEEN, Diamond)))))
           .contains(Move(List(NormalCard(QUEEN, Diamond)))))
       }
     }
@@ -67,25 +67,25 @@ class GameEngineTest extends FunSpec {
 
       describe("When the validMoves are all singles") {
         it("Should pick the lowest single") {
-          assert(GameEngine.getNextMove(allSingles, Move(List.empty))(GameEngine.getNormalCardMoveHeuristic, playerIndicators).contains(allSingles.moves.head))
+          assert(GameEngine.getNextMove(allSingles, Move(List.empty))(GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(allSingles.moves.head))
         }
       }
 
       describe("When the validMoves are all doubles") {
         it("Should pick the lowest double") {
-          assert(GameEngine.getNextMove(allDoubles, Move(List.empty))(GameEngine.getNormalCardMoveHeuristic, playerIndicators).contains(allDoubles.moves.head))
+          assert(GameEngine.getNextMove(allDoubles, Move(List.empty))(GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(allDoubles.moves.head))
         }
       }
 
       describe("When the validMoves are all triples") {
         it("Should pick the lowest triple") {
-          assert(GameEngine.getNextMove(allTriples, Move(List.empty))(GameEngine.getNormalCardMoveHeuristic, playerIndicators).contains(allTriples.moves.head))
+          assert(GameEngine.getNextMove(allTriples, Move(List.empty))(GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(allTriples.moves.head))
         }
       }
 
       describe("When the validMoves are all quads") {
         it("Should pick the lowest quad") {
-          assert(GameEngine.getNextMove(allQuads, Move(List.empty))(GameEngine.getNormalCardMoveHeuristic, playerIndicators).contains(allQuads.moves.head))
+          assert(GameEngine.getNextMove(allQuads, Move(List.empty))(GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(allQuads.moves.head))
         }
       }
 
@@ -98,7 +98,7 @@ class GameEngineTest extends FunSpec {
           ))
           val gameState = Move(List.empty)
           assert(GameEngine.getNextMove(validMoves, gameState)
-          (GameEngine.getNormalCardMoveHeuristic, playerIndicators).contains(double6s))
+          (GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(double6s))
         }
       }
 
@@ -109,7 +109,7 @@ class GameEngineTest extends FunSpec {
           val validMoves: Moves = Moves(List(double5s, triple6s))
           val gameState = Move(List.empty)
           assert(GameEngine.getNextMove(validMoves, gameState)
-          (GameEngine.getNormalCardMoveHeuristic, playerIndicators).contains(triple6s))
+          (GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(triple6s))
         }
       }
 
@@ -120,7 +120,7 @@ class GameEngineTest extends FunSpec {
           val validMoves: Moves = Moves(List(single5, triple6s))
           val gameState = Move(List.empty)
           assert(GameEngine.getNextMove(validMoves, gameState)
-          (GameEngine.getNormalCardMoveHeuristic, playerIndicators).contains(triple6s))
+          (GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(triple6s))
         }
       }
 
@@ -131,7 +131,7 @@ class GameEngineTest extends FunSpec {
           val validMoves: Moves = Moves(List(triple5s, quad7s))
           val gameState = Move(List.empty)
           assert(GameEngine.getNextMove(validMoves, gameState)
-          (GameEngine.getNormalCardMoveHeuristic, playerIndicators).contains(quad7s))
+          (GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(quad7s))
         }
       }
 
@@ -142,7 +142,7 @@ class GameEngineTest extends FunSpec {
           val validMoves: Moves = Moves(List(double5s, quad7s))
           val gameState = Move(List.empty)
           assert(GameEngine.getNextMove(validMoves, gameState)
-          (GameEngine.getNormalCardMoveHeuristic, playerIndicators).contains(quad7s))
+          (GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(quad7s))
         }
       }
 
@@ -153,7 +153,7 @@ class GameEngineTest extends FunSpec {
           val validMoves: Moves = Moves(List(single5, quad7s))
           val gameState = Move(List.empty)
           assert(GameEngine.getNextMove(validMoves, gameState)
-          (GameEngine.getNormalCardMoveHeuristic, playerIndicators).contains(quad7s))
+          (GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(quad7s))
         }
       }
 
@@ -169,25 +169,25 @@ class GameEngineTest extends FunSpec {
         describe("When special move is comprised of a single or multiple 2s") {
           it("Should return single2 or None when only single 2s are valid moves") {
             val validMoves = Moves(List(single2))
-            val result = GameEngine.getNextMove(validMoves, gameState)(GameEngine.getSpecialCardMoveHeuristic, playerInd)
+            val result = GameEngine.getNextMove(validMoves, gameState)(GameEngine.applySpecialCardMoveHeuristic, playerInd)
             assert(result.contains(single2) || result.isEmpty)
           }
 
           it("Should return double2 or None when only double2s are valid moves") {
             val validMoves = Moves(List(double2))
-            val result = GameEngine.getNextMove(validMoves, gameState)(GameEngine.getSpecialCardMoveHeuristic, playerInd)
+            val result = GameEngine.getNextMove(validMoves, gameState)(GameEngine.applySpecialCardMoveHeuristic, playerInd)
             assert(result.contains(double2) || result.isEmpty)
           }
 
           it("Should return triple2 or None when only triple2s are valid moves") {
             val validMoves = Moves(List(triple2))
-            val result = GameEngine.getNextMove(validMoves, gameState)(GameEngine.getSpecialCardMoveHeuristic, playerInd)
+            val result = GameEngine.getNextMove(validMoves, gameState)(GameEngine.applySpecialCardMoveHeuristic, playerInd)
             assert(result.contains(triple2) || result.isEmpty)
           }
 
           it("Should return Joker or None when only Joker is a valid move") {
             val validMoves = Moves(List(joker))
-            val result = GameEngine.getNextMove(validMoves, gameState)(GameEngine.getSpecialCardMoveHeuristic, playerInd)
+            val result = GameEngine.getNextMove(validMoves, gameState)(GameEngine.applySpecialCardMoveHeuristic, playerInd)
             assert(result.contains(joker) || result.isEmpty)
           }
         }
@@ -225,14 +225,14 @@ class GameEngineTest extends FunSpec {
           val gameState = Move(List(NormalCard(FIVE, Club)))
           val allValidMoves = GameUtilities.getValidMoves(GameUtilities.getAllMoves(sampleHand.listOfSimilarCards), gameState)
           assert(GameEngine.getNextMove(allSingles, gameState)
-          (GameEngine.getNormalCardMoveHeuristic, playerIndicators).contains(allSingles.moves.head))
+          (GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(allSingles.moves.head))
         }
 
         it("Should pick a higher single without breaking a set than a lower single that involves breaking a set ") {
           val gameState = Move(List(NormalCard(THREE, Diamond)))
           val allValidMoves = GameUtilities.getValidMoves(GameUtilities.getAllMoves(sampleHand.listOfSimilarCards), gameState)
           assert(GameEngine.getNextMove(allValidMoves, gameState)
-          (GameEngine.getNormalCardMoveHeuristic, playerIndicators).contains(Move(List(NormalCard(SEVEN, Diamond)))))
+          (GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(Move(List(NormalCard(SEVEN, Diamond)))))
         }
 
       }
@@ -242,7 +242,7 @@ class GameEngineTest extends FunSpec {
           val gameState = Move(List(NormalCard(THREE, Diamond), NormalCard(THREE, Club)))
           val allValidMoves = GameUtilities.getValidMoves(GameUtilities.getAllMoves(sampleHand.listOfSimilarCards), gameState)
           assert(GameEngine.getNextMove(allValidMoves, gameState)
-          (GameEngine.getNormalCardMoveHeuristic, playerIndicators).contains(Move(List(NormalCard(SIX, Diamond), NormalCard(SIX, Club)))))
+          (GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(Move(List(NormalCard(SIX, Diamond), NormalCard(SIX, Club)))))
         }
       }
 
@@ -251,7 +251,7 @@ class GameEngineTest extends FunSpec {
           val gameState = Move(List(NormalCard(THREE, Diamond), NormalCard(THREE, Club), NormalCard(THREE, Heart)))
           val allValidMoves = GameUtilities.getValidMoves(GameUtilities.getAllMoves(sampleHand.listOfSimilarCards), gameState)
           assert(GameEngine.getNextMove(allValidMoves, gameState)
-          (GameEngine.getNormalCardMoveHeuristic, playerIndicators).contains(Move(List(NormalCard(FIVE, Diamond),
+          (GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(Move(List(NormalCard(FIVE, Diamond),
             NormalCard(FIVE, Club), NormalCard(FIVE, Heart)))))
         }
       }
@@ -266,28 +266,28 @@ class GameEngineTest extends FunSpec {
         val triple2 = Move(List(SpecialCard(TWO, Diamond), SpecialCard(TWO, Club), SpecialCard(TWO, Heart)))
 
         it("Returns the single2 or none when played on top of a nonEmpty normal card"){
-          val result = GameEngine.getNextMove(Moves(List(single2)), gameState)(GameEngine.getSpecialCardMoveHeuristic, playerInd)
+          val result = GameEngine.getNextMove(Moves(List(single2)), gameState)(GameEngine.applySpecialCardMoveHeuristic, playerInd)
           assert(result.contains(single2) || result.isEmpty)
         }
 
         it("Returns the double2 or none when played on top of a nonEmpty normal card"){
           val currentGameState = Move(List(NormalCard(ACE, Diamond), NormalCard(ACE, Club), NormalCard(ACE, Heart)))
-          val result = GameEngine.getNextMove(Moves(List(double2)), currentGameState)(GameEngine.getSpecialCardMoveHeuristic, playerInd)
+          val result = GameEngine.getNextMove(Moves(List(double2)), currentGameState)(GameEngine.applySpecialCardMoveHeuristic, playerInd)
           assert(result.contains(double2) || result.isEmpty)
         }
 
         it("Returns the triple2 or none when played on top of a nonEmpty normal cards"){
           val currentGameState = Move(List(NormalCard(ACE, Diamond), NormalCard(ACE, Club), NormalCard(ACE, Heart), NormalCard(ACE, Spade)))
-          val result = GameEngine.getNextMove(Moves(List(triple2)), currentGameState)(GameEngine.getSpecialCardMoveHeuristic, playerInd)
+          val result = GameEngine.getNextMove(Moves(List(triple2)), currentGameState)(GameEngine.applySpecialCardMoveHeuristic, playerInd)
           assert(result.contains(triple2) || result.isEmpty)
         }
 
         it("Returns the joker or none when played on top of a nonEmpty normal card(s)"){
           val currentGameState2 = Move(List(NormalCard(ACE, Diamond), NormalCard(ACE, Club), NormalCard(ACE, Heart)))
           val currentGameState3 = Move(List(NormalCard(ACE, Diamond), NormalCard(ACE, Club), NormalCard(ACE, Heart), NormalCard(ACE, Spade)))
-          val result = GameEngine.getNextMove(Moves(List(joker)), gameState)(GameEngine.getSpecialCardMoveHeuristic, playerInd)
-          val result2 = GameEngine.getNextMove(Moves(List(joker)), currentGameState2)(GameEngine.getSpecialCardMoveHeuristic, playerInd)
-          val result3 = GameEngine.getNextMove(Moves(List(joker)), currentGameState3)(GameEngine.getSpecialCardMoveHeuristic, playerInd)
+          val result = GameEngine.getNextMove(Moves(List(joker)), gameState)(GameEngine.applySpecialCardMoveHeuristic, playerInd)
+          val result2 = GameEngine.getNextMove(Moves(List(joker)), currentGameState2)(GameEngine.applySpecialCardMoveHeuristic, playerInd)
+          val result3 = GameEngine.getNextMove(Moves(List(joker)), currentGameState3)(GameEngine.applySpecialCardMoveHeuristic, playerInd)
           assert(result.contains(joker) || result.isEmpty)
           assert(result2.contains(joker) || result2.isEmpty)
           assert(result3.contains(joker) || result3.isEmpty)
@@ -314,27 +314,27 @@ class GameEngineTest extends FunSpec {
 
       it("Should play a 2, if its suit is one-greater-than that of the gameState 2") {
         assert(GameEngine.getNextMove(Moves(List(betterTwoGameState, twoGameState2, betterTwoGameState2)), twoGameState)
-        (GameEngine.getSpecialCardMoveHeuristic, playerInd).contains(betterTwoGameState))
+        (GameEngine.applySpecialCardMoveHeuristic, playerInd).contains(betterTwoGameState))
 
         assert(GameEngine.getNextMove(Moves(List(betterTwoGameState2)), twoGameState2)
-        (GameEngine.getSpecialCardMoveHeuristic, playerInd).contains(betterTwoGameState2))
+        (GameEngine.applySpecialCardMoveHeuristic, playerInd).contains(betterTwoGameState2))
       }
 
       it("Should return either a 2, or none, if the suit difference is > 1") {
-        val result = GameEngine.getNextMove(Moves(List(twoGameState2)), twoGameState)(GameEngine.getSpecialCardMoveHeuristic, playerInd)
+        val result = GameEngine.getNextMove(Moves(List(twoGameState2)), twoGameState)(GameEngine.applySpecialCardMoveHeuristic, playerInd)
         assert(result.contains(twoGameState2) || result.isEmpty)
       }
 
       it("Should return either two 2s, or none, if the gameState involves two 2s") {
-        val result = GameEngine.getNextMove(Moves(List(betterTwo2GameState)), two2GameState)(GameEngine.getSpecialCardMoveHeuristic, playerInd)
+        val result = GameEngine.getNextMove(Moves(List(betterTwo2GameState)), two2GameState)(GameEngine.applySpecialCardMoveHeuristic, playerInd)
         assert(result.contains(betterTwo2GameState) || result.isEmpty)
       }
 
       it("Should return either Joker or None, if gameState involves single or two 2s"){
-        val result1 = GameEngine.getNextMove(Moves(List(Move(List(Joker)))), betterTwo2GameState)(GameEngine.getSpecialCardMoveHeuristic, playerInd)
+        val result1 = GameEngine.getNextMove(Moves(List(Move(List(Joker)))), betterTwo2GameState)(GameEngine.applySpecialCardMoveHeuristic, playerInd)
         assert(result1.contains(Move(List(Joker))) || result1.isEmpty)
 
-        val result2 = GameEngine.getNextMove(Moves(List(Move(List(Joker)))), betterTwoGameState2)(GameEngine.getSpecialCardMoveHeuristic, playerInd)
+        val result2 = GameEngine.getNextMove(Moves(List(Move(List(Joker)))), betterTwoGameState2)(GameEngine.applySpecialCardMoveHeuristic, playerInd)
         assert(result2.contains(Move(List(Joker))) || result2.isEmpty)
       }
     }
@@ -427,22 +427,22 @@ class GameEngineTest extends FunSpec {
     describe("Throws exception when") {
 
       it("Move involves a joker") {
-        assertThrows[IllegalHeuristicFunctionException](GameEngine.getNormalCardMoveHeuristic(Move(List(Joker)), Move(List.empty)))
+        assertThrows[IllegalHeuristicFunctionException](GameEngine.applyNormalCardMoveHeuristic(Move(List(Joker)), Move(List.empty)))
       }
 
       describe("When move involves a 2") {
         it("is a single 2") {
           assertThrows[IllegalHeuristicFunctionException](GameEngine.
-            getNormalCardMoveHeuristic(Move(List(SpecialCard(TWO, Diamond))), Move(List.empty)))
+            applyNormalCardMoveHeuristic(Move(List(SpecialCard(TWO, Diamond))), Move(List.empty)))
         }
         it("is a double 2") {
           assertThrows[IllegalHeuristicFunctionException](GameEngine.
-            getNormalCardMoveHeuristic(Move(List(SpecialCard(TWO, Diamond), SpecialCard(TWO, Heart))),
+            applyNormalCardMoveHeuristic(Move(List(SpecialCard(TWO, Diamond), SpecialCard(TWO, Heart))),
               Move(List.empty)))
         }
         it("is a triple 2") {
           assertThrows[IllegalHeuristicFunctionException](GameEngine.
-            getNormalCardMoveHeuristic(Move(List(SpecialCard(TWO, Diamond), SpecialCard(TWO, Heart), SpecialCard(TWO, Spade))),
+            applyNormalCardMoveHeuristic(Move(List(SpecialCard(TWO, Diamond), SpecialCard(TWO, Heart), SpecialCard(TWO, Spade))),
               Move(List.empty)))
         }
       }
@@ -454,13 +454,13 @@ class GameEngineTest extends FunSpec {
 
       describe("When validMove is a single 4")  {
         it("should return value") {
-          assert(GameEngine.getNormalCardMoveHeuristic(Move(List(NormalCard(FOUR,Heart))), emptyGameState) == 0.25)
+          assert(GameEngine.applyNormalCardMoveHeuristic(Move(List(NormalCard(FOUR,Heart))), emptyGameState) == 0.25)
         }
       }
 
       describe("When validMove is double4s")  {
         it("should return value") {
-          assert(GameEngine.getNormalCardMoveHeuristic(
+          assert(GameEngine.applyNormalCardMoveHeuristic(
             Move(List(NormalCard(FOUR,Heart), NormalCard(FOUR,Spade))),
             emptyGameState) == 0.305)
         }
@@ -468,7 +468,7 @@ class GameEngineTest extends FunSpec {
 
       describe("When validMove is triple4s")  {
         it("should return value") {
-          assert(GameEngine.getNormalCardMoveHeuristic(
+          assert(GameEngine.applyNormalCardMoveHeuristic(
             Move(List(NormalCard(FOUR,Club), NormalCard(FOUR,Heart), NormalCard(FOUR,Spade))),
             emptyGameState) == 0.36)
         }
@@ -476,7 +476,7 @@ class GameEngineTest extends FunSpec {
 
       describe("When validMove is quad4s")  {
         it("should return value") {
-          assert(GameEngine.getNormalCardMoveHeuristic(
+          assert(GameEngine.applyNormalCardMoveHeuristic(
             Move(List(NormalCard(FOUR,Diamond), NormalCard(FOUR,Club),
               NormalCard(FOUR,Heart), NormalCard(FOUR,Spade))),
             emptyGameState) === 0.415)
@@ -491,7 +491,7 @@ class GameEngineTest extends FunSpec {
         it("should return the right value") {
           val gameState = Move(List(NormalCard(FIVE, Spade)))
           val validMove = Move(List(NormalCard(NINE, Diamond)))
-          assert(GameEngine.getNormalCardMoveHeuristic(validMove, gameState, PlayerIndicators(hand)) === 0.835)
+          assert(GameEngine.applyNormalCardMoveHeuristic(validMove, gameState, PlayerIndicators(hand)) === 0.835)
         }
       }
 
@@ -500,7 +500,7 @@ class GameEngineTest extends FunSpec {
         it("should return the right value") {
           val gameState = Move(List(NormalCard(FIVE, Club), NormalCard(FIVE, Spade)))
           val validMove = Move(List(NormalCard(NINE, Diamond), NormalCard(NINE, Spade)))
-          assert(GameEngine.getNormalCardMoveHeuristic(validMove, gameState, PlayerIndicators(hand)) === 0.835)
+          assert(GameEngine.applyNormalCardMoveHeuristic(validMove, gameState, PlayerIndicators(hand)) === 0.835)
         }
       }
 
@@ -509,7 +509,7 @@ class GameEngineTest extends FunSpec {
           val hand = Hand(List(NormalCard(NINE, Diamond), NormalCard(NINE, Club), NormalCard(NINE, Spade)))
           val gameState = Move(List(NormalCard(FIVE, Club), NormalCard(FIVE, Heart), NormalCard(FIVE, Spade)))
           val validMove = Move(List(NormalCard(NINE, Diamond), NormalCard(NINE, Club), NormalCard(NINE, Spade)))
-          assert(GameEngine.getNormalCardMoveHeuristic(validMove, gameState, PlayerIndicators(hand)) === 0.835)
+          assert(GameEngine.applyNormalCardMoveHeuristic(validMove, gameState, PlayerIndicators(hand)) === 0.835)
         }
       }
 
@@ -520,7 +520,7 @@ class GameEngineTest extends FunSpec {
             NormalCard(FIVE, Heart), NormalCard(FIVE, Spade)))
           val validMove = Move(List(NormalCard(NINE, Diamond), NormalCard(NINE, Club),
             NormalCard(NINE, Heart), NormalCard(NINE, Spade)))
-          assert(GameEngine.getNormalCardMoveHeuristic(validMove, gameState, PlayerIndicators(hand)) === 0.835)
+          assert(GameEngine.applyNormalCardMoveHeuristic(validMove, gameState, PlayerIndicators(hand)) === 0.835)
         }
       }
     }
@@ -545,11 +545,11 @@ class GameEngineTest extends FunSpec {
 
     describe("Throws exception when") {
       it("Move involves a NormalCard") {
-        assertThrows[IllegalHeuristicFunctionException](GameEngine.getSpecialCardMoveHeuristic(Move(List(NormalCard(EIGHT, Heart))), Move(List.empty)))
+        assertThrows[IllegalHeuristicFunctionException](GameEngine.applySpecialCardMoveHeuristic(Move(List(NormalCard(EIGHT, Heart))), Move(List.empty)))
       }
 
       it("Move involves a list of NormalCard"){
-        assertThrows[IllegalHeuristicFunctionException](GameEngine.getSpecialCardMoveHeuristic(
+        assertThrows[IllegalHeuristicFunctionException](GameEngine.applySpecialCardMoveHeuristic(
           Move(List(NormalCard(NINE, Club), NormalCard(NINE, Heart), NormalCard(NINE, Spade))), Move(List.empty)))
       }
     }
@@ -560,15 +560,15 @@ class GameEngineTest extends FunSpec {
 
       describe("When gameState is empty") {
         it("Should return playerModifier.specialCardModifier or 0") {
-          val result = GameEngine.getSpecialCardMoveHeuristic(validMove, Move(List.empty), playerIndicators)
+          val result = GameEngine.applySpecialCardMoveHeuristic(validMove, Move(List.empty), playerIndicators)
           assert(result == playerIndicators.specialCardModifier || result == 0)
         }
       }
 
       describe("When gameState is a single or a double") {
         it("Should return playerModifier.specialCardModifier or 0") {
-          val result = GameEngine.getSpecialCardMoveHeuristic(validMove, Move(List(NormalCard(ACE, Heart))), playerIndicators)
-          val result2 = GameEngine.getSpecialCardMoveHeuristic(validMove, Move(List(NormalCard(ACE, Heart), NormalCard(ACE, Spade))), playerIndicators)
+          val result = GameEngine.applySpecialCardMoveHeuristic(validMove, Move(List(NormalCard(ACE, Heart))), playerIndicators)
+          val result2 = GameEngine.applySpecialCardMoveHeuristic(validMove, Move(List(NormalCard(ACE, Heart), NormalCard(ACE, Spade))), playerIndicators)
           assert(result == playerIndicators.specialCardModifier || result == 0)
           assert(result2 == playerIndicators.specialCardModifier || result2 == 0)
         }
@@ -576,9 +576,9 @@ class GameEngineTest extends FunSpec {
 
       describe("When gameState is a triple or higher") {
         it("Should return playerModifier.specialCardModifier or 0") {
-          val result = GameEngine.getSpecialCardMoveHeuristic(validMove,
+          val result = GameEngine.applySpecialCardMoveHeuristic(validMove,
             Move(List(NormalCard(ACE, Club), NormalCard(ACE, Heart), NormalCard(ACE, Spade))), playerIndicators)
-          val result2 = GameEngine.getSpecialCardMoveHeuristic(validMove,
+          val result2 = GameEngine.applySpecialCardMoveHeuristic(validMove,
             Move(List(NormalCard(ACE, Diamond), NormalCard(ACE, Club), NormalCard(ACE, Heart), NormalCard(ACE, Spade))), playerIndicators)
           assert(result == playerIndicators.specialCardModifier || result == 0)
           assert(result2 == playerIndicators.specialCardModifier || result2 == 0)
@@ -596,21 +596,21 @@ class GameEngineTest extends FunSpec {
       describe("When validMove consists of a single 2") {
         describe("When gameState is empty") {
           it("Should return playerModifier.specialCardModifier or 0") {
-            val result = GameEngine.getSpecialCardMoveHeuristic(single2, Move(List.empty), playerIndicators)
+            val result = GameEngine.applySpecialCardMoveHeuristic(single2, Move(List.empty), playerIndicators)
             assert(result == playerIndicators.specialCardModifier || result == 0)
           }
         }
 
         describe("When a single 2 is played on top of a single NormalCard") {
           it("Should return playerModifier.specialCardModifier or 0") {
-            val result = GameEngine.getSpecialCardMoveHeuristic(single2, Move(List(NormalCard(ACE, Diamond))), playerIndicators)
+            val result = GameEngine.applySpecialCardMoveHeuristic(single2, Move(List(NormalCard(ACE, Diamond))), playerIndicators)
             assert(result == playerIndicators.specialCardModifier || result == 0)
           }
         }
 
         describe("When a single 2 is played on top of a double NormalCard"){
           it("Should return playerModifier.specialCardModifier or 0") {
-            val result = GameEngine.getSpecialCardMoveHeuristic(single2,
+            val result = GameEngine.applySpecialCardMoveHeuristic(single2,
               Move(List(NormalCard(ACE, Diamond), NormalCard(ACE, Spade))), playerIndicators)
             assert(result == playerIndicators.specialCardModifier || result == 0)
           }
@@ -619,14 +619,14 @@ class GameEngineTest extends FunSpec {
         describe("When a single 2 is played on top of another single 2") {
           describe("When the 2 being played is one-suit-away from the 2 on top") {
             it("Should return playerModifier.specialCardModifier") {
-              val result = GameEngine.getSpecialCardMoveHeuristic(single2, Move(List(SpecialCard(TWO, Club))), playerIndicators)
+              val result = GameEngine.applySpecialCardMoveHeuristic(single2, Move(List(SpecialCard(TWO, Club))), playerIndicators)
               assert(result == playerIndicators.specialCardModifier)
             }
           }
 
           describe("When the 2 being played is not one-suit-away from the 2 on top") {
             it("Should return playerModifier.specialCardModifier or 0") {
-              val result = GameEngine.getSpecialCardMoveHeuristic(single2, Move(List(SpecialCard(TWO, Diamond))), playerIndicators)
+              val result = GameEngine.applySpecialCardMoveHeuristic(single2, Move(List(SpecialCard(TWO, Diamond))), playerIndicators)
               assert(result == playerIndicators.specialCardModifier || result == 0)
             }
           }
@@ -637,7 +637,7 @@ class GameEngineTest extends FunSpec {
       describe("When validMove consists of multiple 2s") {
         describe("When two 2s are being played") {
           it("Should return playerModifier.specialCardModifier or 0") {
-            val result = GameEngine.getSpecialCardMoveHeuristic(double2,
+            val result = GameEngine.applySpecialCardMoveHeuristic(double2,
               Move(List(NormalCard(EIGHT, Diamond), NormalCard(EIGHT, Club), NormalCard(EIGHT, Heart))), playerIndicators)
             assert(result == playerIndicators.specialCardModifier || result == 0)
           }
@@ -645,7 +645,7 @@ class GameEngineTest extends FunSpec {
 
         describe("When three 2s are being played") {
           it("Should return playerModifier.specialCardModifier or 0") {
-            val result = GameEngine.getSpecialCardMoveHeuristic(triple2,
+            val result = GameEngine.applySpecialCardMoveHeuristic(triple2,
               Move(List(NormalCard(EIGHT, Diamond), NormalCard(EIGHT, Club), NormalCard(EIGHT, Heart), NormalCard(EIGHT, Spade))), playerIndicators)
             assert(result == playerIndicators.specialCardModifier || result == 0)
           }
@@ -653,7 +653,7 @@ class GameEngineTest extends FunSpec {
 
         describe("When two 2s are being played on top of existing two 2s"){
           it("should not care about off-by-one suit-burn preferences since it is still an expensive move and return 0/modifier value") {
-            val result = GameEngine.getSpecialCardMoveHeuristic(double2,
+            val result = GameEngine.applySpecialCardMoveHeuristic(double2,
               Move(List(SpecialCard(TWO, Diamond), SpecialCard(TWO, Club))), playerIndicators)
             assert(result == playerIndicators.specialCardModifier || result == 0)
           }

--- a/src/test/scala/GameEngineTest.scala
+++ b/src/test/scala/GameEngineTest.scala
@@ -457,7 +457,7 @@ class GameEngineTest extends FunSpec {
 
       describe("When validMove is a single 4")  {
         it("should return value") {
-          assert(GameEngine.applyNormalCardMoveHeuristic(Move(List(NormalCard(FOUR,Heart))), emptyGameState) == 0.25)
+          assert(GameEngine.applyNormalCardMoveHeuristic(Move(List(NormalCard(FOUR,Heart))), emptyGameState).likelihood == 0.25)
         }
       }
 
@@ -465,7 +465,7 @@ class GameEngineTest extends FunSpec {
         it("should return value") {
           assert(GameEngine.applyNormalCardMoveHeuristic(
             Move(List(NormalCard(FOUR,Heart), NormalCard(FOUR,Spade))),
-            emptyGameState) == 0.305)
+            emptyGameState).likelihood == 0.305)
         }
       }
 
@@ -473,7 +473,7 @@ class GameEngineTest extends FunSpec {
         it("should return value") {
           assert(GameEngine.applyNormalCardMoveHeuristic(
             Move(List(NormalCard(FOUR,Club), NormalCard(FOUR,Heart), NormalCard(FOUR,Spade))),
-            emptyGameState) == 0.36)
+            emptyGameState).likelihood == 0.36)
         }
       }
 
@@ -482,7 +482,7 @@ class GameEngineTest extends FunSpec {
           assert(GameEngine.applyNormalCardMoveHeuristic(
             Move(List(NormalCard(FOUR,Diamond), NormalCard(FOUR,Club),
               NormalCard(FOUR,Heart), NormalCard(FOUR,Spade))),
-            emptyGameState) === 0.415)
+            emptyGameState).likelihood === 0.415)
         }
       }
     }
@@ -494,7 +494,7 @@ class GameEngineTest extends FunSpec {
         it("should return the right value") {
           val gameState = Move(List(NormalCard(FIVE, Spade)))
           val validMove = Move(List(NormalCard(NINE, Diamond)))
-          assert(GameEngine.applyNormalCardMoveHeuristic(validMove, gameState, PlayerIndicators(hand)) === 0.835)
+          assert(GameEngine.applyNormalCardMoveHeuristic(validMove, gameState, PlayerIndicators(hand)).likelihood === 0.824)
         }
       }
 
@@ -503,7 +503,7 @@ class GameEngineTest extends FunSpec {
         it("should return the right value") {
           val gameState = Move(List(NormalCard(FIVE, Club), NormalCard(FIVE, Spade)))
           val validMove = Move(List(NormalCard(NINE, Diamond), NormalCard(NINE, Spade)))
-          assert(GameEngine.applyNormalCardMoveHeuristic(validMove, gameState, PlayerIndicators(hand)) === 0.835)
+          assert(GameEngine.applyNormalCardMoveHeuristic(validMove, gameState, PlayerIndicators(hand)).likelihood === 0.824)
         }
       }
 
@@ -512,7 +512,7 @@ class GameEngineTest extends FunSpec {
           val hand = Hand(List(NormalCard(NINE, Diamond), NormalCard(NINE, Club), NormalCard(NINE, Spade)))
           val gameState = Move(List(NormalCard(FIVE, Club), NormalCard(FIVE, Heart), NormalCard(FIVE, Spade)))
           val validMove = Move(List(NormalCard(NINE, Diamond), NormalCard(NINE, Club), NormalCard(NINE, Spade)))
-          assert(GameEngine.applyNormalCardMoveHeuristic(validMove, gameState, PlayerIndicators(hand)) === 0.835)
+          assert(GameEngine.applyNormalCardMoveHeuristic(validMove, gameState, PlayerIndicators(hand)).likelihood === 0.824)
         }
       }
 
@@ -523,7 +523,7 @@ class GameEngineTest extends FunSpec {
             NormalCard(FIVE, Heart), NormalCard(FIVE, Spade)))
           val validMove = Move(List(NormalCard(NINE, Diamond), NormalCard(NINE, Club),
             NormalCard(NINE, Heart), NormalCard(NINE, Spade)))
-          assert(GameEngine.applyNormalCardMoveHeuristic(validMove, gameState, PlayerIndicators(hand)) === 0.835)
+          assert(GameEngine.applyNormalCardMoveHeuristic(validMove, gameState, PlayerIndicators(hand)).likelihood === 0.824)
         }
       }
     }

--- a/src/test/scala/GameEngineTest.scala
+++ b/src/test/scala/GameEngineTest.scala
@@ -684,12 +684,14 @@ class GameEngineTest extends FunSpec {
         val r6 = GameEngine.applyNormalCardHeuristicWithMoveSizeModifier(move6)
         val r7 = GameEngine.applyNormalCardHeuristicWithMoveSizeModifier(move7)
         val r8 = GameEngine.applyNormalCardHeuristicWithMoveSizeModifier(move8)
-        val results = List(r1, r2, r3, r4, r5, r6, r7, r8)
+        val results = List(move1.copy(likelihood=r1),move2.copy(likelihood=r2), move3.copy(likelihood=r3),
+                        move4.copy(likelihood=r4), move5.copy(likelihood=r5), move6.copy(likelihood=r6),
+                        move7.copy(likelihood=r7), move8.copy(likelihood=r8))
         val expected: List[Double] = List(0.25, 0.305, 0.36, 0.415, 0.285, 0.23, 0.175, 0.12)
 
-        assert(results.max == r4)
-        assert(results.min == r8)
-        assert(((results zip expected).map(tuple => tuple._1 === tuple._2).forall(x => x)))
+        assert(results.maxBy(_.likelihood).likelihood == r4)
+        assert(results.minBy(_.likelihood).likelihood == r8)
+        assert(((results zip expected).map(tuple => tuple._1.likelihood === tuple._2).forall(x => x)))
 
       }
     }
@@ -703,8 +705,8 @@ class GameEngineTest extends FunSpec {
     val gameState = Move(List(NormalCard(SIX, Heart)))
 
     describe("When the moveFaceValue and the gameStateFaceValue are the same (suit-burn") {
-      it("Should return infinity") {
-        assert(GameEngine.applyNormalCardHeuristicWithPenaltyForBreakingSets(single7, Move(List(NormalCard(SEVEN, Club))), 1).isInfinite)
+      it("Should return 1") {
+        assert(GameEngine.applyNormalCardHeuristicWithPenaltyForBreakingSets(single7, Move(List(NormalCard(SEVEN, Club))), 1) == 1.0d)
         assert(GameEngine.applyNormalCardHeuristicWithPenaltyForBreakingSets(single7,
           Move(List(NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club))), 1).isInfinite)
       }

--- a/src/test/scala/GameEngineTest.scala
+++ b/src/test/scala/GameEngineTest.scala
@@ -425,7 +425,7 @@ class GameEngineTest extends FunSpec {
 
   }
 
-  describe("tests for getNormalCardMoveHeuristic()") {
+  describe("tests for applyNormalCardMoveHeuristic()") {
 
     describe("Throws exception when") {
 
@@ -436,16 +436,16 @@ class GameEngineTest extends FunSpec {
       describe("When move involves a 2") {
         it("is a single 2") {
           assertThrows[IllegalHeuristicFunctionException](GameEngine.
-            applyNormalCardMoveHeuristic(Move(List(SpecialCard(TWO, Diamond))), Move(List.empty)))
+            applyNormalCardMoveHeuristic(Move(List(TWO_Diamond)), Move(List.empty)))
         }
         it("is a double 2") {
           assertThrows[IllegalHeuristicFunctionException](GameEngine.
-            applyNormalCardMoveHeuristic(Move(List(SpecialCard(TWO, Diamond), SpecialCard(TWO, Heart))),
+            applyNormalCardMoveHeuristic(Move(List(TWO_Diamond, TWO_Heart)),
               Move(List.empty)))
         }
         it("is a triple 2") {
           assertThrows[IllegalHeuristicFunctionException](GameEngine.
-            applyNormalCardMoveHeuristic(Move(List(SpecialCard(TWO, Diamond), SpecialCard(TWO, Heart), SpecialCard(TWO, Spade))),
+            applyNormalCardMoveHeuristic(Move(List(TWO_Diamond, TWO_Heart, TWO_Spade)),
               Move(List.empty)))
         }
       }
@@ -457,14 +457,14 @@ class GameEngineTest extends FunSpec {
 
       describe("When validMove is a single 4")  {
         it("should return value") {
-          assert(GameEngine.applyNormalCardMoveHeuristic(Move(List(NormalCard(FOUR,Heart))), emptyGameState).likelihood == 0.25)
+          assert(GameEngine.applyNormalCardMoveHeuristic(Move(List(FOUR_Heart)), emptyGameState).likelihood == 0.25)
         }
       }
 
       describe("When validMove is double4s")  {
         it("should return value") {
           assert(GameEngine.applyNormalCardMoveHeuristic(
-            Move(List(NormalCard(FOUR,Heart), NormalCard(FOUR,Spade))),
+            Move(List(FOUR_Heart, FOUR_Spade)),
             emptyGameState).likelihood == 0.305)
         }
       }
@@ -472,7 +472,7 @@ class GameEngineTest extends FunSpec {
       describe("When validMove is triple4s")  {
         it("should return value") {
           assert(GameEngine.applyNormalCardMoveHeuristic(
-            Move(List(NormalCard(FOUR,Club), NormalCard(FOUR,Heart), NormalCard(FOUR,Spade))),
+            Move(List(FOUR_Club, FOUR_Heart, FOUR_Spade)),
             emptyGameState).likelihood == 0.36)
         }
       }
@@ -480,9 +480,28 @@ class GameEngineTest extends FunSpec {
       describe("When validMove is quad4s")  {
         it("should return value") {
           assert(GameEngine.applyNormalCardMoveHeuristic(
-            Move(List(NormalCard(FOUR,Diamond), NormalCard(FOUR,Club),
-              NormalCard(FOUR,Heart), NormalCard(FOUR,Spade))),
+            Move(List(FOUR_Diamond, FOUR_Club, FOUR_Heart, FOUR_Spade)),
             emptyGameState).likelihood === 0.415)
+        }
+      }
+
+      describe("When validMove involves a WildCard in it") {
+        it("Should return value less than when no wildcards are involved") {
+          assert(GameEngine.applyNormalCardMoveHeuristic(
+            Move(List(THREE_Heart(4), FOUR_Club, FOUR_Heart, FOUR_Spade)),
+            emptyGameState).likelihood < 0.415)
+        }
+
+        it("Should return value less than when one wildcard is involved") {
+          assert(GameEngine.applyNormalCardMoveHeuristic(
+            Move(List(THREE_Heart(4), THREE_Spade(4), FOUR_Heart, FOUR_Spade)),
+            emptyGameState).likelihood < 0.406)
+        }
+
+        it("Should return value less than when two wildcards are involved") {
+          assert(GameEngine.applyNormalCardMoveHeuristic(
+            Move(List(THREE_Diamond(4), THREE_Heart(4), THREE_Spade(4), FOUR_Spade)),
+            emptyGameState).likelihood < 0.404)
         }
       }
     }
@@ -492,8 +511,8 @@ class GameEngineTest extends FunSpec {
       describe("When gameState is a single") {
         val hand = Hand(List(NormalCard(NINE, Spade)))
         it("should return the right value") {
-          val gameState = Move(List(NormalCard(FIVE, Spade)))
-          val validMove = Move(List(NormalCard(NINE, Diamond)))
+          val gameState = Move(List(FIVE_Spade))
+          val validMove = Move(List(NINE_Diamond))
           assert(GameEngine.applyNormalCardMoveHeuristic(validMove, gameState, PlayerIndicators(hand)).likelihood === 0.824)
         }
       }
@@ -501,30 +520,52 @@ class GameEngineTest extends FunSpec {
       describe("When gameState is a double") {
         val hand = Hand(List(NormalCard(NINE, Club), NormalCard(NINE, Spade)))
         it("should return the right value") {
-          val gameState = Move(List(NormalCard(FIVE, Club), NormalCard(FIVE, Spade)))
-          val validMove = Move(List(NormalCard(NINE, Diamond), NormalCard(NINE, Spade)))
+          val gameState = Move(List(FIVE_Club, FIVE_Spade))
+          val validMove = Move(List(NINE_Diamond, NINE_Spade))
           assert(GameEngine.applyNormalCardMoveHeuristic(validMove, gameState, PlayerIndicators(hand)).likelihood === 0.824)
         }
       }
 
       describe("When gameState is a triple") {
         it("should return the right value") {
-          val hand = Hand(List(NormalCard(NINE, Diamond), NormalCard(NINE, Club), NormalCard(NINE, Spade)))
-          val gameState = Move(List(NormalCard(FIVE, Club), NormalCard(FIVE, Heart), NormalCard(FIVE, Spade)))
-          val validMove = Move(List(NormalCard(NINE, Diamond), NormalCard(NINE, Club), NormalCard(NINE, Spade)))
+          val hand = Hand(List(NINE_Diamond, NINE_Club, NINE_Spade))
+          val gameState = Move(List(FIVE_Club, FIVE_Heart, FIVE_Spade))
+          val validMove = Move(List(NINE_Diamond, NINE_Club, NINE_Spade))
           assert(GameEngine.applyNormalCardMoveHeuristic(validMove, gameState, PlayerIndicators(hand)).likelihood === 0.824)
         }
       }
 
       describe("When gameState is a quadruple") {
-        val hand = Hand(List(NormalCard(NINE, Diamond), NormalCard(NINE, Club), NormalCard(NINE, Heart), NormalCard(NINE, Spade)))
+        val hand = Hand(List(NINE_Diamond, NINE_Club, NINE_Heart, NINE_Spade))
         it("should return the right value") {
-          val gameState = Move(List(NormalCard(FIVE, Diamond), NormalCard(FIVE, Club),
-            NormalCard(FIVE, Heart), NormalCard(FIVE, Spade)))
-          val validMove = Move(List(NormalCard(NINE, Diamond), NormalCard(NINE, Club),
-            NormalCard(NINE, Heart), NormalCard(NINE, Spade)))
+          val gameState = Move(List(FIVE_Diamond, FIVE_Club, FIVE_Heart, FIVE_Spade))
+          val validMove = Move(List(NINE_Diamond, NINE_Club, NINE_Heart, NINE_Spade))
           assert(GameEngine.applyNormalCardMoveHeuristic(validMove, gameState, PlayerIndicators(hand)).likelihood === 0.824)
         }
+      }
+
+      describe("When move involves WildCard(s) in it ") {
+        it("Should return value less than without a wildcard") {
+          val hand = Hand(List(NINE_Diamond, NINE_Club, NINE_Heart, NINE_Spade))
+          val gameState = Move(List(FIVE_Diamond, FIVE_Club, FIVE_Heart, FIVE_Spade))
+          val validMove = Move(List(THREE_Diamond(9), NINE_Club, NINE_Heart, NINE_Spade))
+          assert(GameEngine.applyNormalCardMoveHeuristic(validMove, gameState, PlayerIndicators(hand)).likelihood < 0.824)
+        }
+
+        it("Should return value less than with one wildcard") {
+          val hand = Hand(List(NINE_Diamond, NINE_Club, NINE_Heart, NINE_Spade))
+          val gameState = Move(List(FIVE_Diamond, FIVE_Club, FIVE_Heart, FIVE_Spade))
+          val validMove = Move(List(THREE_Diamond(9), THREE_Club(9), NINE_Heart, NINE_Spade))
+          assert(GameEngine.applyNormalCardMoveHeuristic(validMove, gameState, PlayerIndicators(hand)).likelihood < 0.416)
+        }
+
+        it("Should return value less than with two wildcards") {
+          val hand = Hand(List(NINE_Diamond, NINE_Club, NINE_Heart, NINE_Spade))
+          val gameState = Move(List(FIVE_Diamond, FIVE_Club, FIVE_Heart, FIVE_Spade))
+          val validMove = Move(List(THREE_Diamond(9), THREE_Club(9), THREE_Heart(9), NINE_Spade))
+          assert(GameEngine.applyNormalCardMoveHeuristic(validMove, gameState, PlayerIndicators(hand)).likelihood < 0.277)
+        }
+
       }
     }
 

--- a/src/test/scala/GameEngineTest.scala
+++ b/src/test/scala/GameEngineTest.scala
@@ -16,7 +16,7 @@ class GameEngineTest extends FunSpec {
   describe("tests for getNextMove()"){
 
     describe("When validMoves is empty"){
-      it("Should return an None") {
+      it("Should return None") {
         val playerIndicators: PlayerIndicators = PlayerIndicators(Hand(List.empty))
         assert(GameEngine.getNextMove(Moves(List.empty), Move(List.empty))
         (GameEngine.applyNormalCardMoveHeuristic, playerIndicators).isEmpty)
@@ -25,10 +25,10 @@ class GameEngineTest extends FunSpec {
 
     describe("When validMoves.size is 1 and it is a normalCard") {
       it("Should return the validMove") {
-        val gameState = Move(List(NormalCard(JACK, Heart)))
-        val validMoves = Moves(List(Move(List(NormalCard(QUEEN, Diamond)))))
-        assert(GameEngine.getNextMove(validMoves, gameState)(GameEngine.applyNormalCardMoveHeuristic, PlayerIndicators(Hand(List(NormalCard(QUEEN, Diamond)))))
-          .contains(Move(List(NormalCard(QUEEN, Diamond)))))
+        val gameState = Move(List(JACK_Heart))
+        val validMoves = Moves(List(Move(List(QUEEN_Diamond))))
+        assert(GameEngine.getNextMove(validMoves, gameState)(GameEngine.applyNormalCardMoveHeuristic, PlayerIndicators(Hand(List(QUEEN_Diamond))))
+          .contains(Move(List(QUEEN_Diamond))))
       }
     }
 
@@ -52,19 +52,19 @@ class GameEngineTest extends FunSpec {
 
       val playerIndicators: PlayerIndicators = PlayerIndicators(Hand(List.empty))
 
-      val allSingles = Moves(List(Move(List(NormalCard(SIX, Spade))), Move(List(NormalCard(SEVEN, Heart))), Move(List(NormalCard(EIGHT, Diamond)))))
+      val allSingles = Moves(List(Move(List(SIX_Spade)), Move(List(SEVEN_Heart)), Move(List(EIGHT_Diamond))))
       val allDoubles= Moves(List(
-        Move(List(NormalCard(SIX, Heart), NormalCard(SIX, Spade))),
-        Move(List(NormalCard(SEVEN, Club), NormalCard(SEVEN, Heart))),
-        Move(List(NormalCard(EIGHT, Diamond), NormalCard(EIGHT, Club)))))
+        Move(List(SIX_Heart, SIX_Spade)),
+        Move(List(SEVEN_Club, SEVEN_Heart)),
+        Move(List(EIGHT_Diamond, EIGHT_Club))))
       val allTriples = Moves(List(
-        Move(List(NormalCard(SIX, Club), NormalCard(SIX, Heart), NormalCard(SIX, Spade))),
-        Move(List(NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club), NormalCard(SEVEN, Heart))),
-        Move(List(NormalCard(EIGHT, Diamond), NormalCard(EIGHT, Club), NormalCard(EIGHT, Heart)))))
+        Move(List(SIX_Club, SIX_Heart, SIX_Spade)),
+        Move(List(SEVEN_Diamond, SEVEN_Club, SEVEN_Heart)),
+        Move(List(EIGHT_Diamond, EIGHT_Club, EIGHT_Heart))))
       val allQuads = Moves(List(
-        Move(List(NormalCard(SIX, Diamond), NormalCard(SIX, Club), NormalCard(SIX, Heart), NormalCard(SIX, Spade))),
-        Move(List(NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club), NormalCard(SEVEN, Heart), NormalCard(SEVEN, Spade))),
-        Move(List(NormalCard(EIGHT, Diamond), NormalCard(EIGHT, Club), NormalCard(EIGHT, Heart), NormalCard(EIGHT, Spade)))))
+        Move(List(SIX_Diamond, SIX_Club, SIX_Heart, SIX_Spade)),
+        Move(List(SEVEN_Diamond, SEVEN_Club, SEVEN_Heart, SEVEN_Spade)),
+        Move(List(EIGHT_Diamond, EIGHT_Club, EIGHT_Heart, EIGHT_Spade))))
 
       describe("When the validMoves are all singles") {
         it("Should pick the lowest single") {
@@ -92,9 +92,9 @@ class GameEngineTest extends FunSpec {
 
       describe("When there is a slightly higher double than a lower single") {
         it("Should pick the slightly higher double") {
-          val double6s = Move(List(NormalCard(SIX, Diamond), NormalCard(SIX, Club)))
+          val double6s = Move(List(SIX_Diamond, SIX_Club))
           val validMoves: Moves = Moves(List(
-            Move(List(NormalCard(FIVE, Spade))),
+            Move(List(FIVE_Spade)),
             double6s
           ))
           val gameState = Move(List.empty)
@@ -105,8 +105,8 @@ class GameEngineTest extends FunSpec {
 
       describe("When there is a slightly higher triple than a lower double") {
         it("Should pick the slightly higher triple") {
-          val double5s = Move(List(NormalCard(FIVE, Club), NormalCard(FIVE, Spade)))
-          val triple6s = Move(List(NormalCard(SIX, Diamond), NormalCard(SIX, Club), NormalCard(SIX, Heart)))
+          val double5s = Move(List(FIVE_Club, FIVE_Spade))
+          val triple6s = Move(List(SIX_Diamond, SIX_Club, SIX_Heart))
           val validMoves: Moves = Moves(List(double5s, triple6s))
           val gameState = Move(List.empty)
           assert(GameEngine.getNextMove(validMoves, gameState)
@@ -116,8 +116,8 @@ class GameEngineTest extends FunSpec {
 
       describe("When there is a slightly higher triple than a lower single") {
         it("Should pick the slightly higher triple") {
-          val single5 = Move(List(NormalCard(FIVE, Club)))
-          val triple6s = Move(List(NormalCard(SIX, Diamond), NormalCard(SIX, Club), NormalCard(SIX, Heart)))
+          val single5 = Move(List(FIVE_Club))
+          val triple6s = Move(List(SIX_Diamond, SIX_Club, SIX_Heart))
           val validMoves: Moves = Moves(List(single5, triple6s))
           val gameState = Move(List.empty)
           assert(GameEngine.getNextMove(validMoves, gameState)
@@ -127,8 +127,8 @@ class GameEngineTest extends FunSpec {
 
       describe("When there is a slightly higher quad than a lower triple") {
         it("Should pick the slightly higher quad") {
-          val triple5s = Move(List(NormalCard(FIVE, Diamond), NormalCard(FIVE, Club), NormalCard(FIVE, Heart)))
-          val quad7s = Move(List(NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club), NormalCard(SEVEN, Heart), NormalCard(SEVEN, Spade)))
+          val triple5s = Move(List(FIVE_Diamond, FIVE_Club, FIVE_Heart))
+          val quad7s = Move(List(SEVEN_Diamond, SEVEN_Club, SEVEN_Heart, SEVEN_Spade))
           val validMoves: Moves = Moves(List(triple5s, quad7s))
           val gameState = Move(List.empty)
           assert(GameEngine.getNextMove(validMoves, gameState)
@@ -138,8 +138,8 @@ class GameEngineTest extends FunSpec {
 
       describe("When there is a slightly higher quad than a lower double") {
         it("Should pick the slightly higher quad") {
-          val double5s = Move(List(NormalCard(FIVE, Diamond), NormalCard(FIVE, Club)))
-          val quad7s = Move(List(NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club), NormalCard(SEVEN, Heart), NormalCard(SEVEN, Spade)))
+          val double5s = Move(List(FIVE_Diamond, FIVE_Club))
+          val quad7s = Move(List(SEVEN_Diamond, SEVEN_Club, SEVEN_Heart, SEVEN_Spade))
           val validMoves: Moves = Moves(List(double5s, quad7s))
           val gameState = Move(List.empty)
           assert(GameEngine.getNextMove(validMoves, gameState)
@@ -149,8 +149,8 @@ class GameEngineTest extends FunSpec {
 
       describe("When there is a slightly higher quad than a lower single") {
         it("Should pick the slightly higher quad") {
-          val single5 = Move(List(NormalCard(FIVE, Diamond)))
-          val quad7s = Move(List(NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club), NormalCard(SEVEN, Heart), NormalCard(SEVEN, Spade)))
+          val single5 = Move(List(FIVE_Diamond))
+          val quad7s = Move(List(SEVEN_Diamond, SEVEN_Club, SEVEN_Heart, SEVEN_Spade))
           val validMoves: Moves = Moves(List(single5, quad7s))
           val gameState = Move(List.empty)
           assert(GameEngine.getNextMove(validMoves, gameState)
@@ -163,9 +163,9 @@ class GameEngineTest extends FunSpec {
         val randomHand = Hand(GameUtilities.dealNewHand(4, Consants.totalNumberOfCards).listOfCards.slice(0, 6))
         val playerInd = PlayerIndicators(randomHand)
         val joker = Move(List(Joker))
-        val single2 = Move(List(SpecialCard(TWO, Diamond)))
-        val double2 = Move(List(SpecialCard(TWO, Diamond), SpecialCard(TWO, Club)))
-        val triple2 = Move(List(SpecialCard(TWO, Diamond), SpecialCard(TWO, Club), SpecialCard(TWO, Heart)))
+        val single2 = Move(List(TWO_Diamond))
+        val double2 = Move(List(TWO_Diamond, TWO_Club))
+        val triple2 = Move(List(TWO_Diamond, TWO_Club, TWO_Heart))
 
         describe("When special move is comprised of a single or multiple 2s") {
           it("Should return single2 or None when only single 2s are valid moves") {
@@ -209,21 +209,21 @@ class GameEngineTest extends FunSpec {
       // Plays Joker or NONE when it is a triple, quad
 
       val allSingles = Moves(List(
-        Move(List(NormalCard(FIVE, Diamond))),
-        Move(List(NormalCard(SIX, Spade))),
-        Move(List(NormalCard(SEVEN, Diamond)))))
+        Move(List(FIVE_Diamond)),
+        Move(List(SIX_Spade)),
+        Move(List(SEVEN_Diamond))))
 
       val sampleHand = Hand(List(
-        NormalCard(FOUR, Diamond), NormalCard(FOUR, Club), NormalCard(FOUR, Heart), NormalCard(FOUR, Spade),
-        NormalCard(FIVE, Diamond), NormalCard(FIVE, Club), NormalCard(FIVE, Heart),
-        NormalCard(SIX, Diamond), NormalCard(SIX, Club),
-        NormalCard(SEVEN, Diamond)
+        FOUR_Diamond, FOUR_Club, FOUR_Heart, FOUR_Spade,
+        FIVE_Diamond, FIVE_Club, FIVE_Heart,
+        SIX_Diamond, SIX_Club,
+        SEVEN_Diamond
       ))
       val playerIndicators = PlayerIndicators(sampleHand)
 
       describe("When gameState is a low single") {
         it("Should pick the lowest single that minimizes the delta in faceValue") {
-          val gameState = Move(List(NormalCard(FIVE, Club)))
+          val gameState = Move(List(FIVE_Club))
           assert(GameEngine.getNextMove(allSingles, gameState)
           (GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(Move(List(SEVEN_Diamond))))
         }
@@ -232,7 +232,7 @@ class GameEngineTest extends FunSpec {
           val gameState = Move(List(FOUR_Diamond))
           val allValidMoves = GameUtilities.getValidMoves(GameUtilities.getAllMoves(sampleHand.listOfSimilarCards), gameState)
           assert(GameEngine.getNextMove(allValidMoves, gameState)
-          (GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(Move(List(NormalCard(SEVEN, Diamond)))))
+          (GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(Move(List(SEVEN_Diamond))))
         }
 
       }
@@ -242,7 +242,7 @@ class GameEngineTest extends FunSpec {
           val gameState = Move(List(FOUR_Diamond, FOUR_Club))
           val allValidMoves = GameUtilities.getValidMoves(GameUtilities.getAllMoves(sampleHand.listOfSimilarCards), gameState)
           assert(GameEngine.getNextMove(allValidMoves, gameState)
-          (GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(Move(List(NormalCard(SIX, Diamond), NormalCard(SIX, Club)))))
+          (GameEngine.applyNormalCardMoveHeuristic, playerIndicators).contains(Move(List(SIX_Diamond, SIX_Club))))
         }
       }
 
@@ -256,13 +256,13 @@ class GameEngineTest extends FunSpec {
       }
 
       describe("When specialMoves are available") {
-        val gameState = Move(List(NormalCard(ACE, Spade)))
+        val gameState = Move(List(ACE_Spade))
         val randomHand = Hand(GameUtilities.dealNewHand(4, Consants.totalNumberOfCards).listOfCards.slice(0, 6))
         val playerInd = PlayerIndicators(randomHand)
         val joker = Move(List(Joker))
-        val single2 = Move(List(SpecialCard(TWO, Diamond)))
-        val double2 = Move(List(SpecialCard(TWO, Diamond), SpecialCard(TWO, Club)))
-        val triple2 = Move(List(SpecialCard(TWO, Diamond), SpecialCard(TWO, Club), SpecialCard(TWO, Heart)))
+        val single2 = Move(List(TWO_Diamond))
+        val double2 = Move(List(TWO_Diamond, TWO_Club))
+        val triple2 = Move(List(TWO_Diamond, TWO_Club, TWO_Heart))
 
         it("Returns the single2 or none when played on top of a nonEmpty normal card"){
           val result = GameEngine.getNextMove(Moves(List(single2)), gameState)(GameEngine.applySpecialCardMoveHeuristic, playerInd)
@@ -270,20 +270,20 @@ class GameEngineTest extends FunSpec {
         }
 
         it("Returns the double2 or none when played on top of a nonEmpty normal card"){
-          val currentGameState = Move(List(NormalCard(ACE, Diamond), NormalCard(ACE, Club), NormalCard(ACE, Heart)))
+          val currentGameState = Move(List(ACE_Diamond, ACE_Club, ACE_Heart))
           val result = GameEngine.getNextMove(Moves(List(double2)), currentGameState)(GameEngine.applySpecialCardMoveHeuristic, playerInd)
           assert(result.contains(double2) || result.isEmpty)
         }
 
         it("Returns the triple2 or none when played on top of a nonEmpty normal cards"){
-          val currentGameState = Move(List(NormalCard(ACE, Diamond), NormalCard(ACE, Club), NormalCard(ACE, Heart), NormalCard(ACE, Spade)))
+          val currentGameState = Move(List(ACE_Diamond, ACE_Club, ACE_Heart, ACE_Spade))
           val result = GameEngine.getNextMove(Moves(List(triple2)), currentGameState)(GameEngine.applySpecialCardMoveHeuristic, playerInd)
           assert(result.contains(triple2) || result.isEmpty)
         }
 
         it("Returns the joker or none when played on top of a nonEmpty normal card(s)"){
-          val currentGameState2 = Move(List(NormalCard(ACE, Diamond), NormalCard(ACE, Club), NormalCard(ACE, Heart)))
-          val currentGameState3 = Move(List(NormalCard(ACE, Diamond), NormalCard(ACE, Club), NormalCard(ACE, Heart), NormalCard(ACE, Spade)))
+          val currentGameState2 = Move(List(ACE_Diamond, ACE_Club, ACE_Heart))
+          val currentGameState3 = Move(List(ACE_Diamond, ACE_Club, ACE_Heart, ACE_Spade))
           val result = GameEngine.getNextMove(Moves(List(joker)), gameState)(GameEngine.applySpecialCardMoveHeuristic, playerInd)
           val result2 = GameEngine.getNextMove(Moves(List(joker)), currentGameState2)(GameEngine.applySpecialCardMoveHeuristic, playerInd)
           val result3 = GameEngine.getNextMove(Moves(List(joker)), currentGameState3)(GameEngine.applySpecialCardMoveHeuristic, playerInd)
@@ -302,12 +302,12 @@ class GameEngineTest extends FunSpec {
       // Prioritizes off-by-one suit-burns (Diamonds, Hearts)
       // Plays 2 or None otherwise
       // Plays Joker or None otherwise
-      val twoGameState = Move(List(SpecialCard(TWO, Diamond)))
-      val betterTwoGameState = Move(List(SpecialCard(TWO, Club)))
-      val twoGameState2 = Move(List(SpecialCard(TWO, Heart)))
-      val betterTwoGameState2 = Move(List(SpecialCard(TWO, Spade)))
-      val two2GameState = Move(List(SpecialCard(TWO, Diamond), SpecialCard(TWO, Club)))
-      val betterTwo2GameState = Move(List(SpecialCard(TWO, Heart), SpecialCard(TWO, Spade)))
+      val twoGameState = Move(List(TWO_Diamond))
+      val betterTwoGameState = Move(List(TWO_Club))
+      val twoGameState2 = Move(List(TWO_Heart))
+      val betterTwoGameState2 = Move(List(TWO_Spade))
+      val two2GameState = Move(List(TWO_Diamond, TWO_Club))
+      val betterTwo2GameState = Move(List(TWO_Heart, TWO_Spade))
       val randomHand = Hand(GameUtilities.dealNewHand(4, Consants.totalNumberOfCards).listOfCards.slice(0, 6))
       val playerInd = PlayerIndicators(randomHand)
 
@@ -356,9 +356,9 @@ class GameEngineTest extends FunSpec {
         val randomHand = Hand(GameUtilities.dealNewHand(4, Consants.totalNumberOfCards).listOfCards.slice(0, 6))
         val playerInd = PlayerIndicators(randomHand)
         val validMoves = Moves(List(
-          Move(List(SpecialCard(TWO, Diamond))),
-          Move(List(SpecialCard(TWO, Heart))),
-          Move(List(SpecialCard(TWO, Diamond), SpecialCard(TWO, Heart))),
+          Move(List(TWO_Diamond)),
+          Move(List(TWO_Heart)),
+          Move(List(TWO_Diamond, TWO_Heart)),
           Move(List(Joker)),
         ))
         val gameState = Move(List.empty)
@@ -373,49 +373,37 @@ class GameEngineTest extends FunSpec {
 
     describe("When only normal moves are available") {
       it("Should definitively return a move") {
-        val hand = Hand(List(
-          NormalCard(SIX, Diamond),
-          NormalCard(QUEEN, Heart),
-          NormalCard(ACE, Diamond),
-          NormalCard(ACE, Heart),
-        ))
+        val hand = Hand(List(SIX_Diamond, QUEEN_Heart, ACE_Diamond, ACE_Heart))
         val playerInd = PlayerIndicators(hand)
         val validMoves = Moves(List(
-          Move(List(NormalCard(SIX, Diamond))),
-          Move(List(NormalCard(QUEEN, Heart))),
-          Move(List(NormalCard(ACE, Diamond))),
-          Move(List(NormalCard(ACE, Heart))),
-          Move(List(NormalCard(ACE, Diamond), NormalCard(ACE, Heart)))
+          Move(List(SIX_Diamond)),
+          Move(List(QUEEN_Heart)),
+          Move(List(ACE_Diamond)),
+          Move(List(ACE_Heart)),
+          Move(List(ACE_Diamond, ACE_Heart))
         ))
         val gameState = Move(List.empty)
         val result = GameEngine.getNextMoveWrapper(validMoves, gameState)(playerInd)
-        assert(result.contains(Move(List(NormalCard(SIX, Diamond)))))
+        assert(result.contains(Move(List(SIX_Diamond))))
       }
     }
 
     describe("When both normal and special moves are available") {
       it("Should only return a normalCard move and NOT a specialCard move") {
-        val hand = Hand(List(
-          NormalCard(SIX, Diamond),
-          NormalCard(QUEEN, Heart),
-          NormalCard(ACE, Diamond),
-          NormalCard(ACE, Heart),
-          SpecialCard(TWO, Spade),
-          Joker
-        ))
+        val hand = Hand(List(SIX_Diamond, QUEEN_Heart, ACE_Diamond, ACE_Heart, TWO_Spade, Joker))
         val playerInd = PlayerIndicators(hand)
         val validMoves = Moves(List(
-          Move(List(NormalCard(SEVEN, Diamond))),
-          Move(List(NormalCard(QUEEN, Heart))),
-          Move(List(NormalCard(ACE, Diamond))),
-          Move(List(NormalCard(ACE, Heart))),
-          Move(List(NormalCard(ACE, Diamond), NormalCard(ACE, Heart))),
-          Move(List(SpecialCard(TWO, Spade))),
+          Move(List(SEVEN_Diamond)),
+          Move(List(QUEEN_Heart)),
+          Move(List(ACE_Diamond)),
+          Move(List(ACE_Heart)),
+          Move(List(ACE_Diamond, ACE_Heart)),
+          Move(List(TWO_Spade)),
           Move(List(Joker)),
         ))
         val gameState = Move(List.empty)
         val result = GameEngine.getNextMoveWrapper(validMoves, gameState)(playerInd)
-        assert(result.contains(Move(List(NormalCard(SEVEN, Diamond)))))
+        assert(result.contains(Move(List(SEVEN_Diamond))))
         assert(result.get.cards match {
           case List(NormalCard(_,_), _*) => true
           case _ => false

--- a/src/test/scala/GameEssentialsTest.scala
+++ b/src/test/scala/GameEssentialsTest.scala
@@ -1,7 +1,8 @@
-import game.{Hand, NormalCard, WildCard}
+import game.{Hand, Joker, Move, NormalCard, WildCard}
 import org.scalatest.FunSpec
 import game.FaceValue._
 import game.Suits._
+import utils.Consants._
 
 class GameEssentialsTest extends FunSpec {
 
@@ -48,5 +49,62 @@ class GameEssentialsTest extends FunSpec {
       }
 
     }
+
   }
+
+
+
+  describe("Tests for Move case class") {
+
+    describe("Tests for highestCard()") {
+
+      describe("When move size is 1") {
+        it("Returns the only card in hand") {
+          val move = Move(List(NINE_Spade))
+          val move2 = Move(List(THREE_Diamond(14)))
+          val move3 = Move(List(TWO_Spade))
+          val move4 = Move(List(Joker))
+          assert(move.highestCard == NINE_Spade)
+          assert(move2.highestCard == THREE_Diamond(14))
+          assert(move3.highestCard == TWO_Spade)
+          assert(move4.highestCard == Joker)
+        }
+      }
+
+      describe("When move size is 4") {
+        describe("When highest card is a WildCard assuming a value") {
+          it("Should return the WildCard") {
+            val move = Move(List(THREE_Spade(10), TEN_Diamond, TEN_Club, TEN_Heart))
+            assert(move.highestCard == THREE_Spade(10))
+          }
+        }
+
+        describe("When highest card is a NormalCard") {
+          it("Should return the NormalCard") {
+            val move = Move(List(TEN_Diamond, TEN_Club, TEN_Heart, TEN_Spade))
+            assert(move.highestCard == TEN_Spade)
+          }
+        }
+
+        describe("When highest card is a SpecialCard") {
+          it("Should return the SpecialCard") {
+            val move = Move(List(TWO_Diamond, TWO_Club, TWO_Heart, TWO_Spade))
+            assert(move.highestCard == TWO_Spade)
+          }
+        }
+
+
+        describe("When highest card is a tie between a WildCard and a NormalCard") {
+          it("Should return the NormalCard") {
+            val move = Move(List(THREE_Spade(10), TEN_Diamond, TEN_Club, TEN_Spade))
+            assert(move.highestCard == THREE_Spade(10))
+          }
+        }
+      }
+
+    }
+
+  }
+
+
 }

--- a/src/test/scala/GameEssentialsTest.scala
+++ b/src/test/scala/GameEssentialsTest.scala
@@ -1,4 +1,4 @@
-import game.{Hand, NormalCard}
+import game.{Hand, NormalCard, WildCard}
 import org.scalatest.FunSpec
 import game.FaceValue._
 import game.Suits._
@@ -27,7 +27,8 @@ class GameEssentialsTest extends FunSpec {
 
       it("should return a weaknessFactor of 3") {
         val hand = Hand(List(
-          NormalCard(THREE, Diamond), NormalCard(FOUR, Club), NormalCard(FOUR, Spade),
+          WildCard(THREE, Diamond),
+          NormalCard(FOUR, Club), NormalCard(FOUR, Spade),
           NormalCard(FIVE, Club),
           NormalCard(EIGHT, Diamond), NormalCard(EIGHT, Spade),
           NormalCard(JACK, Club),
@@ -37,12 +38,13 @@ class GameEssentialsTest extends FunSpec {
         assert(hand.weaknessFactor == 3)
       }
 
-      it("should return a weaknessFactor of 11") {
+      it("should return a weaknessFactor of 10 and not include threes in the calculation") {
         val hand = Hand(List(
-          NormalCard(THREE, Diamond), NormalCard(THREE, Club), NormalCard(THREE, Spade),
+          WildCard(THREE, Diamond), WildCard(THREE, Club), WildCard(THREE, Spade),
+          NormalCard(FOUR, Diamond), NormalCard(FOUR, Club), NormalCard(FOUR, Spade),
           NormalCard(ACE, Diamond), NormalCard(ACE, Heart), NormalCard(ACE, Spade)
         ))
-        assert(hand.weaknessFactor == 11)
+        assert(hand.weaknessFactor == 10)
       }
 
     }

--- a/src/test/scala/GameEssentialsTest.scala
+++ b/src/test/scala/GameEssentialsTest.scala
@@ -52,8 +52,6 @@ class GameEssentialsTest extends FunSpec {
 
   }
 
-
-
   describe("Tests for Move case class") {
 
     describe("Tests for highestCard()") {

--- a/src/test/scala/GameEssentialsTest.scala
+++ b/src/test/scala/GameEssentialsTest.scala
@@ -104,6 +104,51 @@ class GameEssentialsTest extends FunSpec {
 
     }
 
+    describe("Tests for numberOfNormalCards()") {
+
+      describe("When numberOfNormalCards is 0") {
+        it("Should return 0 when move is comprised of special cards") {
+          val move = Move(List(TWO_Heart, TWO_Spade))
+          val move2 = Move(List(Joker))
+          assert(move.numberOfNormalcards == 0)
+          assert(move2.numberOfNormalcards == 0)
+        }
+
+        it("Should return 0 when move is comprised of WildCards") {
+          val move = Move(List(THREE_Diamond(12), THREE_Club(12)))
+          assert(move.numberOfNormalcards == 0)
+        }
+      }
+
+      describe("When numberOfNormalCards is 1") {
+        it("Should return 1") {
+          val move = Move(List(THREE_Diamond(11), THREE_Club(11), THREE_Heart(11), JACK_Spade))
+          assert(move.numberOfNormalcards == 1)
+        }
+      }
+
+      describe("When numberOfNormalCards is 2") {
+        it("Should return 2") {
+          val move = Move(List(THREE_Diamond(11), THREE_Club(11), JACK_Heart, JACK_Spade))
+          assert(move.numberOfNormalcards == 2)
+        }
+      }
+
+      describe("When numberOfNormalCards is 3") {
+        it("Should return 3") {
+          val move = Move(List(THREE_Diamond(11), JACK_Club, JACK_Heart, JACK_Spade))
+          assert(move.numberOfNormalcards == 3)
+        }
+      }
+
+      describe("When numberOfNormalCards is 4") {
+        it("Should return 4") {
+          val move = Move(List(JACK_Diamond, JACK_Club, JACK_Heart, JACK_Spade))
+          assert(move.numberOfNormalcards == 4)
+        }
+      }
+    }
+
   }
 
 

--- a/src/test/scala/GameEssentialsTest.scala
+++ b/src/test/scala/GameEssentialsTest.scala
@@ -149,6 +149,44 @@ class GameEssentialsTest extends FunSpec {
       }
     }
 
+    describe("Tests for moveFacevalue") {
+
+      describe("When move.cards is empty") {
+        it("Should return 0") {
+          assert(Move(List.empty).moveFaceValue == 0)
+        }
+      }
+
+      describe("When highestCard is a WildCard") {
+        it("Should return the assumed value") {
+          val move = Move(List(THREE_Spade(13), KING_Heart))
+          assert(move.moveFaceValue == 13)
+        }
+      }
+
+      describe("When highestCard is a NormalCard") {
+        it("Should return the integer value") {
+          val move = Move(List(SIX_Club, SIX_Heart, SIX_Spade))
+          assert(move.moveFaceValue == SIX_Spade.intValue)
+        }
+      }
+
+      describe("When highestCard is a SpecialCard") {
+        it("Should return the integer value") {
+          val move = Move(List(TWO_Heart, TWO_Spade))
+          assert(move.moveFaceValue == TWO_Spade.intValue)
+        }
+      }
+
+      describe("When highestCard is a Joker") {
+        it("Should return -1") {
+          val move = Move(List(Joker))
+          assert(move.moveFaceValue == Joker.intValue)
+        }
+      }
+
+    }
+
   }
 
 

--- a/src/test/scala/GameUtilitiesTest.scala
+++ b/src/test/scala/GameUtilitiesTest.scala
@@ -1,4 +1,4 @@
-import game.{GameUtilities, Hand, Joker, Move, Moves, NormalCard, SpecialCard}
+import game.{Card, GameUtilities, Hand, Joker, Move, Moves, NormalCard, SpecialCard, WildCard}
 import org.scalatest.FunSpec
 import utils.Consants
 
@@ -1116,8 +1116,79 @@ class GameUtilitiesTest extends FunSpec {
         assert(GameUtilities.filterOnlyNormalCardMoves(Moves(listOfSpecialMoves ++ listOfNormalMoves)) == validNormalMoves)
       }
     }
+  }
 
+  describe("tests for getWildCardListFromIntermediateList()") {
 
+    describe("When intermediate list is empty") {
+      it("Should return empty list") {
+        val intermediateList = List.empty
+        assert(GameUtilities.getWildCardListFromIntermediateList(intermediateList).isEmpty)
+      }
+    }
+
+    describe("When intermediate list is a List(List.empty)") {
+      it("Should return empty list") {
+        val intermediateList = List(List.empty)
+        assert(GameUtilities.getWildCardListFromIntermediateList(intermediateList).isEmpty)
+      }
+    }
+
+    describe("When intermediateList does NOT have a list of cards with 3s in it") {
+      it("Should return empty list") {
+        val intermediateList = List(
+          List(NormalCard(FOUR, Heart)),
+          List(NormalCard(SIX, Diamond), NormalCard(SIX, Club)),
+          List(NormalCard(EIGHT, Club), NormalCard(EIGHT, Heart), NormalCard(EIGHT, Spade)),
+          List(NormalCard(TEN, Diamond), NormalCard(TEN, Club), NormalCard(TEN, Heart), NormalCard(TEN, Spade)),
+          List(SpecialCard(TWO, Spade)),
+          List(Joker)
+        )
+        assert(GameUtilities.getWildCardListFromIntermediateList(intermediateList).isEmpty)
+      }
+    }
+
+    describe("When intermediateList has a list of card(s) with 3s in it") {
+      val intermediateList = List(
+        List(NormalCard(FOUR, Heart)),
+        List(NormalCard(SIX, Diamond), NormalCard(SIX, Club)),
+        List(NormalCard(EIGHT, Club), NormalCard(EIGHT, Heart), NormalCard(EIGHT, Spade)),
+        List(NormalCard(TEN, Diamond), NormalCard(TEN, Club), NormalCard(TEN, Heart), NormalCard(TEN, Spade)),
+        List(SpecialCard(TWO, Spade)),
+        List(Joker)
+      )
+
+      describe("When the list of 3s is of size 1") {
+        it("Should return a list of size 1") {
+          val intermediate: List[List[Card]] = intermediateList :+ List(WildCard(THREE, Diamond))
+          assert(GameUtilities.getWildCardListFromIntermediateList(intermediate).size == 1)
+        }
+      }
+
+      describe("When the list of 3s is of size 2") {
+        it("Should return a list of size 2") {
+          val intermediate: List[List[Card]] = intermediateList :+
+            List(WildCard(THREE, Diamond), WildCard(THREE, Club))
+          assert(GameUtilities.getWildCardListFromIntermediateList(intermediate).size == 2)
+        }
+      }
+
+      describe("When the list of 3s is of size 3") {
+        it("Should return a list of size 3") {
+          val intermediate: List[List[Card]] = intermediateList :+
+            List(WildCard(THREE, Diamond), WildCard(THREE, Club), WildCard(THREE, Heart))
+          assert(GameUtilities.getWildCardListFromIntermediateList(intermediate).size == 3)
+        }
+      }
+
+      describe("When the list of 3s is of size 4") {
+        it("Should return a list of size 4") {
+          val intermediate: List[List[Card]] = intermediateList :+
+            List(WildCard(THREE, Diamond), WildCard(THREE, Club), WildCard(THREE, Heart), WildCard(THREE, Spade))
+          assert(GameUtilities.getWildCardListFromIntermediateList(intermediate).size == 4)
+        }
+      }
+    }
   }
 
 }

--- a/src/test/scala/GameUtilitiesTest.scala
+++ b/src/test/scala/GameUtilitiesTest.scala
@@ -1470,7 +1470,79 @@ class GameUtilitiesTest extends FunSpec {
 
   }
 
-  describe("tests for getOptimalWildCardValue()") {
+  describe("tests for getMoveWithOptimalWildCardValue()") {
+
+    describe("When move is not fully comprised of WildCards") {
+      it("Should throw an exception when move supplied has a normalCard in it") {
+        val validMove = Move(List(THREE_Club(14), THREE_Heart(14), THREE_Spade(14), ACE_Spade))
+        assertThrows[IllegalMoveSuppliedException](GameUtilities.getMoveWithOptimalWildCardValue(validMove, Move(List.empty)))
+      }
+
+      it("Should throw an exception when move supplied has a specialCard in it") {
+        val validMove = Move(List(TWO_Spade))
+        val validMove2 = Move(List(Joker))
+        assertThrows[IllegalMoveSuppliedException](GameUtilities.getMoveWithOptimalWildCardValue(validMove, Move(List.empty)))
+        assertThrows[IllegalMoveSuppliedException](GameUtilities.getMoveWithOptimalWildCardValue(validMove2, Move(List.empty)))
+      }
+    }
+
+    describe("When move is comprised fully of wildcards") {
+      describe("When gameState is EMPTY") {
+        it("Should return the move itself") {
+          val validMove = Move(List(THREE_Heart(14), THREE_Spade(14)))
+          assert(GameUtilities.getMoveWithOptimalWildCardValue(validMove, Move(List.empty)) == validMove)
+        }
+      }
+
+      describe("When gameState is NON EMPTY") {
+
+        describe("When gameState is a single") {
+          it("Should return move itself when it cannot burn") {
+            val validMove = Move(List(THREE_Spade(14)))
+            val gameState = Move(List(TEN_Spade))
+            assert(GameUtilities.getMoveWithOptimalWildCardValue(validMove, gameState) == validMove)
+          }
+
+          it("Should return move with faceValue == gameState.moveFaceValue if it CAN burn") {
+            val validMove = Move(List(THREE_Spade(14)))
+            val gameState = Move(List(TEN_Heart))
+            assert(GameUtilities.getMoveWithOptimalWildCardValue(validMove, gameState) == Move(List(THREE_Spade(10))))
+          }
+        }
+
+        describe("When gameState is a double") {
+          it("Should return move itself when it cannot burn") {
+            val validMove = Move(List(THREE_Heart(14), THREE_Spade(14)))
+            val gameState = Move(List(TEN_Heart, TEN_Spade))
+            assert(GameUtilities.getMoveWithOptimalWildCardValue(validMove, gameState) == validMove)
+          }
+
+          it("Should return move with faceValue == gameState.moveFaceValue if it CAN burn") {
+            val validMove = Move(List(THREE_Heart(14), THREE_Spade(14)))
+            val gameState = Move(List(TEN_Diamond, TEN_Club))
+            assert(GameUtilities.getMoveWithOptimalWildCardValue(validMove, gameState)
+              == Move(List(THREE_Heart(10), THREE_Spade(10))))
+          }
+        }
+
+        describe("When gameState is a triple") {
+          it("Should return move itself when it cannot burn") {
+            val validMove = Move(List(THREE_Diamond(14), THREE_Club(14), THREE_Heart(14)))
+            val gameState = Move(List(TEN_Club, TEN_Heart, TEN_Spade))
+            assert(GameUtilities.getMoveWithOptimalWildCardValue(validMove, gameState) == validMove)
+          }
+
+          it("Should return move with faceValue == gameState.moveFaceValue if it CAN burn") {
+            val validMove = Move(List(THREE_Club(14), THREE_Heart(14), THREE_Spade(14)))
+            val gameState = Move(List(TEN_Diamond, TEN_Club, TEN_Heart))
+            assert(GameUtilities.getMoveWithOptimalWildCardValue(validMove, gameState)
+              == Move(List(THREE_Club(10), THREE_Heart(10), THREE_Spade(10))))
+          }
+        }
+
+      }
+
+    }
 
   }
 

--- a/src/test/scala/GameUtilitiesTest.scala
+++ b/src/test/scala/GameUtilitiesTest.scala
@@ -5,6 +5,7 @@ import utils.Consants
 import scala.util.Random
 import game.FaceValue._
 import game.Suits._
+import player.Player
 
 class GameUtilitiesTest extends FunSpec {
 
@@ -1187,6 +1188,50 @@ class GameUtilitiesTest extends FunSpec {
             List(WildCard(THREE, Diamond), WildCard(THREE, Club), WildCard(THREE, Heart), WildCard(THREE, Spade))
           assert(GameUtilities.getWildCardListFromIntermediateList(intermediate).size == 4)
         }
+      }
+    }
+  }
+
+  describe("Tests for getNewHand()") {
+    val currentHand = Hand(List(
+      NormalCard(SIX, Diamond),
+      NormalCard(SIX, Heart),
+      NormalCard(EIGHT, Club),
+      NormalCard(TEN, Heart),
+      NormalCard(ACE, Diamond),
+      NormalCard(ACE, Heart),
+      SpecialCard(TWO, Diamond),
+      Joker,
+    ))
+    val player = Player("Test", currentHand)
+    describe("When the movePlayed is none"){
+      it("Should return the same hand") {
+        assert(GameUtilities.getNewHand(player.hand, None) == currentHand)
+      }
+    }
+
+    describe("When the movePlayed does not involve a hand"){
+      it("Should return the same hand") {
+        assert(GameUtilities.getNewHand(player.hand, Some(Move(List(NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Spade)))))
+          == currentHand)
+      }
+    }
+
+    describe("When the movePlayed involves a card in the hand"){
+      describe("When the move played is a normalCard") {
+        it("Should return the hand minus the played cards") {
+          assert(GameUtilities.getNewHand(player.hand, Some(Move(List(NormalCard(ACE, Diamond), NormalCard(ACE, Heart)))))
+            == Hand(currentHand.listOfCards.slice(0,4) ++ currentHand.listOfCards.slice(6, 8)))
+        }
+      }
+    }
+
+    describe("When the move played is a specialCard") {
+      it("Should return the hand minus the played cards") {
+        assert(GameUtilities.getNewHand(player.hand, Some(Move(List(SpecialCard(TWO, Diamond)))))
+          == Hand(currentHand.listOfCards.slice(0,6) ++ currentHand.listOfCards.slice(7, 8)))
+        assert(GameUtilities.getNewHand(player.hand, Some(Move(List(Joker))))
+          == Hand(currentHand.listOfCards.slice(0,7)))
       }
     }
   }

--- a/src/test/scala/GameUtilitiesTest.scala
+++ b/src/test/scala/GameUtilitiesTest.scala
@@ -1162,6 +1162,15 @@ class GameUtilitiesTest extends FunSpec {
 
   describe("tests for getWildCardListFromIntermediateList()") {
 
+    val intermediateList = List(
+      List(FOUR_Heart),
+      List(SIX_Diamond, SIX_Club),
+      List(EIGHT_Club, EIGHT_Heart, EIGHT_Spade),
+      List(TEN_Diamond, TEN_Club, TEN_Heart, TEN_Spade),
+      List(TWO_Spade),
+      List(Joker)
+    )
+
     describe("When intermediate list is empty") {
       it("Should return empty list") {
         val intermediateList = List.empty
@@ -1178,31 +1187,15 @@ class GameUtilitiesTest extends FunSpec {
 
     describe("When intermediateList does NOT have a list of cards with 3s in it") {
       it("Should return empty list") {
-        val intermediateList = List(
-          List(NormalCard(FOUR, Heart)),
-          List(NormalCard(SIX, Diamond), NormalCard(SIX, Club)),
-          List(NormalCard(EIGHT, Club), NormalCard(EIGHT, Heart), NormalCard(EIGHT, Spade)),
-          List(NormalCard(TEN, Diamond), NormalCard(TEN, Club), NormalCard(TEN, Heart), NormalCard(TEN, Spade)),
-          List(SpecialCard(TWO, Spade)),
-          List(Joker)
-        )
         assert(GameUtilities.getWildCardListFromIntermediateList(intermediateList).isEmpty)
       }
     }
 
     describe("When intermediateList has a list of card(s) with 3s in it") {
-      val intermediateList = List(
-        List(NormalCard(FOUR, Heart)),
-        List(NormalCard(SIX, Diamond), NormalCard(SIX, Club)),
-        List(NormalCard(EIGHT, Club), NormalCard(EIGHT, Heart), NormalCard(EIGHT, Spade)),
-        List(NormalCard(TEN, Diamond), NormalCard(TEN, Club), NormalCard(TEN, Heart), NormalCard(TEN, Spade)),
-        List(SpecialCard(TWO, Spade)),
-        List(Joker)
-      )
 
       describe("When the list of 3s is of size 1") {
         it("Should return a list of size 1") {
-          val intermediate: List[List[Card]] = intermediateList :+ List(WildCard(THREE, Diamond))
+          val intermediate: List[List[Card]] = intermediateList :+ List(THREE_Diamond)
           assert(GameUtilities.getWildCardListFromIntermediateList(intermediate).size == 1)
         }
       }
@@ -1210,7 +1203,7 @@ class GameUtilitiesTest extends FunSpec {
       describe("When the list of 3s is of size 2") {
         it("Should return a list of size 2") {
           val intermediate: List[List[Card]] = intermediateList :+
-            List(WildCard(THREE, Diamond), WildCard(THREE, Club))
+            List(THREE_Diamond, THREE_Club)
           assert(GameUtilities.getWildCardListFromIntermediateList(intermediate).size == 2)
         }
       }
@@ -1218,7 +1211,7 @@ class GameUtilitiesTest extends FunSpec {
       describe("When the list of 3s is of size 3") {
         it("Should return a list of size 3") {
           val intermediate: List[List[Card]] = intermediateList :+
-            List(WildCard(THREE, Diamond), WildCard(THREE, Club), WildCard(THREE, Heart))
+            List(THREE_Diamond, THREE_Club, THREE_Heart)
           assert(GameUtilities.getWildCardListFromIntermediateList(intermediate).size == 3)
         }
       }
@@ -1226,7 +1219,7 @@ class GameUtilitiesTest extends FunSpec {
       describe("When the list of 3s is of size 4") {
         it("Should return a list of size 4") {
           val intermediate: List[List[Card]] = intermediateList :+
-            List(WildCard(THREE, Diamond), WildCard(THREE, Club), WildCard(THREE, Heart), WildCard(THREE, Spade))
+            List(THREE_Diamond, THREE_Club, THREE_Heart, THREE_Spade)
           assert(GameUtilities.getWildCardListFromIntermediateList(intermediate).size == 4)
         }
       }
@@ -1235,45 +1228,63 @@ class GameUtilitiesTest extends FunSpec {
 
   describe("Tests for getNewHand()") {
     val currentHand = Hand(List(
-      NormalCard(SIX, Diamond),
-      NormalCard(SIX, Heart),
-      NormalCard(EIGHT, Club),
-      NormalCard(TEN, Heart),
-      NormalCard(ACE, Diamond),
-      NormalCard(ACE, Heart),
-      SpecialCard(TWO, Diamond),
-      Joker,
-    ))
+      THREE_Club, THREE_Heart,
+      SIX_Diamond, SIX_Heart,
+      EIGHT_Club, TEN_Heart,
+      ACE_Diamond, ACE_Heart,
+      TWO_Diamond, Joker))
     val player = Player("Test", currentHand)
+
     describe("When the movePlayed is none"){
       it("Should return the same hand") {
         assert(GameUtilities.getNewHand(player.hand, None) == currentHand)
       }
     }
 
-    describe("When the movePlayed does not involve a hand"){
-      it("Should return the same hand") {
-        assert(GameUtilities.getNewHand(player.hand, Some(Move(List(NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Spade)))))
+    describe("When the movePlayed does not involve a card in the hand"){
+      it("Should return the same hand when the move is composed of Normal Cards") {
+        assert(GameUtilities.getNewHand(player.hand, Some(Move(List(SEVEN_Diamond, SEVEN_Spade))))
           == currentHand)
       }
+
+      it("Should return the same hand when the move is composed of Special Cards") {
+        assert(GameUtilities.getNewHand(player.hand, Some(Move(List(TWO_Club, TWO_Heart))))
+          == currentHand)
+      }
+
+      it("Should return the same hand when the move is composed of WildCards") {
+        assert(GameUtilities.getNewHand(player.hand, Some(Move(List(THREE_Diamond(8), THREE_Spade(8)))))
+          == currentHand)
+      }
+
     }
 
     describe("When the movePlayed involves a card in the hand"){
+
       describe("When the move played is a normalCard") {
         it("Should return the hand minus the played cards") {
-          assert(GameUtilities.getNewHand(player.hand, Some(Move(List(NormalCard(ACE, Diamond), NormalCard(ACE, Heart)))))
-            == Hand(currentHand.listOfCards.slice(0,4) ++ currentHand.listOfCards.slice(6, 8)))
+          assert(GameUtilities.getNewHand(player.hand, Some(Move(List(ACE_Diamond, ACE_Heart))))
+            == Hand(currentHand.listOfCards.slice(0,6) ++ currentHand.listOfCards.slice(8, 10)))
         }
       }
-    }
 
-    describe("When the move played is a specialCard") {
-      it("Should return the hand minus the played cards") {
-        assert(GameUtilities.getNewHand(player.hand, Some(Move(List(SpecialCard(TWO, Diamond)))))
-          == Hand(currentHand.listOfCards.slice(0,6) ++ currentHand.listOfCards.slice(7, 8)))
-        assert(GameUtilities.getNewHand(player.hand, Some(Move(List(Joker))))
-          == Hand(currentHand.listOfCards.slice(0,7)))
+      describe("When the move played is a specialCard") {
+        it("Should return the hand minus the played cards") {
+          assert(GameUtilities.getNewHand(player.hand, Some(Move(List(TWO_Diamond))))
+            == Hand(currentHand.listOfCards.slice(0,8) ++ currentHand.listOfCards.slice(9, 10)))
+          assert(GameUtilities.getNewHand(player.hand, Some(Move(List(Joker))))
+            == Hand(currentHand.listOfCards.slice(0,9)))
+        }
       }
+
+      describe("When the move played is a WildCard") {
+        it("Should return the hand minus the played cards") {
+          assert(GameUtilities.getNewHand(player.hand,
+            Some(Move(List(THREE_Club(14), THREE_Heart(14), ACE_Diamond, ACE_Heart))))
+          == Hand(currentHand.listOfCards.slice(2, 6) ++ currentHand.listOfCards.slice(8,10)))
+        }
+      }
+
     }
   }
 
@@ -1357,6 +1368,22 @@ class GameUtilitiesTest extends FunSpec {
         assert(GameUtilities.getWildCardListFromIntermediateList(intermediateList :+ oneWildCardList) == oneWildCardList)
       }
     }
+
+  }
+
+  describe("tests for getNewHand()") {
+
+  }
+
+  describe("tests for addThreesToMoves()") {
+
+  }
+
+  describe("tests for getOptimalWildCardValue()") {
+
+  }
+
+  describe("tests for assignWildCardsOptimally()") {
 
   }
 

--- a/src/test/scala/GameUtilitiesTest.scala
+++ b/src/test/scala/GameUtilitiesTest.scala
@@ -1101,19 +1101,19 @@ class GameUtilitiesTest extends FunSpec {
     describe("When validMoves comprise only of NormalCard moves") {
 
       it("Should return the validMoves itself") {
-        assert(GameUtilities.filterOnlyNormalCardMoves(validNormalMoves) == validNormalMoves)
+        assert(GameUtilities.filterNonSpecialCardMoves(validNormalMoves) == validNormalMoves)
       }
     }
 
     describe("When validMoves comprise only of SpecialCard moves") {
       it("Should return empty list") {
-        assert(GameUtilities.filterOnlyNormalCardMoves(validSpecialMoves).moves.isEmpty)
+        assert(GameUtilities.filterNonSpecialCardMoves(validSpecialMoves).moves.isEmpty)
       }
     }
 
     describe("When validMoves comprise of both specialCard moves and NormalCard moves"){
       it("Should return list containing only NormalCard moves") {
-        assert(GameUtilities.filterOnlyNormalCardMoves(Moves(listOfSpecialMoves ++ listOfNormalMoves)) == validNormalMoves)
+        assert(GameUtilities.filterNonSpecialCardMoves(Moves(listOfSpecialMoves ++ listOfNormalMoves)) == validNormalMoves)
       }
     }
   }

--- a/src/test/scala/GameUtilitiesTest.scala
+++ b/src/test/scala/GameUtilitiesTest.scala
@@ -1254,4 +1254,22 @@ class GameUtilitiesTest extends FunSpec {
     }
   }
 
+  describe("tests for getCardAssumedByWildCard()") {
+    it("Should return right value for a 3 diamond assuming a ten") {
+      assert(GameUtilities.getCardAssumedByWildCard(THREE_Diamond(10)) == TEN_Diamond)
+    }
+
+    it("Should return right value for a 3 club assuming an eight") {
+      assert(GameUtilities.getCardAssumedByWildCard(THREE_Club(8)) == EIGHT_Club)
+    }
+
+    it("Should return right value for a 3 heart assuming a jack") {
+      assert(GameUtilities.getCardAssumedByWildCard(THREE_Heart(11)) == JACK_Heart)
+    }
+
+    it("Should return right value for a 3 spade assuming an ace") {
+      assert(GameUtilities.getCardAssumedByWildCard(THREE_Spade(14)) == ACE_Spade)
+    }
+  }
+
 }

--- a/src/test/scala/GameUtilitiesTest.scala
+++ b/src/test/scala/GameUtilitiesTest.scala
@@ -933,6 +933,11 @@ class GameUtilitiesTest extends FunSpec {
     it("should return the right value when supplied card is a Joker") {
       assert(GameUtilities.cardOrderValue(Joker) == 52)
     }
+
+    it("Should return the right value when supplied card is a WildCard assuming another card") {
+      assert(GameUtilities.cardOrderValue(THREE_Spade(8)) == GameUtilities.cardOrderValue(EIGHT_Spade))
+    }
+
   }
 
   describe("tests for isOnlySpecialMovesAvailable()") {

--- a/src/test/scala/GameUtilitiesTest.scala
+++ b/src/test/scala/GameUtilitiesTest.scala
@@ -1441,11 +1441,36 @@ class GameUtilitiesTest extends FunSpec {
 
   }
 
-  describe("tests for getOptimalWildCardValue()") {
+  describe("tests for assignWildCardsOptimally()") {
+
+    val validMoves = Moves(List(
+      Move(List(THREE_Spade(6), SIX_Diamond, SIX_Club)),
+      Move(List(NINE_Club, NINE_Heart, NINE_Spade)),
+      Move(List(THREE_Club(11), THREE_Heart(11), JACK_Diamond)),
+    ))
+
+    describe("When there are no validMoves comprised purely of WildCards") {
+      it("Should return the same list of validMoves") {
+        assert(GameUtilities.assignWildCardsOptimally(validMoves, Move(List.empty)) == validMoves)
+      }
+    }
+
+    describe("When there are validMoves comprising purely of WildCards") {
+      it("Should return the expected result") {
+        val gameState = Move(List(FIVE_Diamond, FIVE_Club, FIVE_Heart))
+        val allValidMoves = Moves(validMoves.moves ++ List(
+          Move(List(THREE_Club(14), THREE_Heart(14), THREE_Spade(14)))
+        ))
+        val expectedResult = Moves(validMoves.moves ++ List(
+          Move(List(THREE_Club(5), THREE_Heart(5), THREE_Spade(5)))
+        ))
+        assert(GameUtilities.assignWildCardsOptimally(allValidMoves, gameState) == expectedResult)
+      }
+    }
 
   }
 
-  describe("tests for assignWildCardsOptimally()") {
+  describe("tests for getOptimalWildCardValue()") {
 
   }
 

--- a/src/test/scala/GameUtilitiesTest.scala
+++ b/src/test/scala/GameUtilitiesTest.scala
@@ -6,6 +6,7 @@ import scala.util.Random
 import game.FaceValue._
 import game.Suits._
 import player.Player
+import utils.Consants._
 
 class GameUtilitiesTest extends FunSpec {
 
@@ -908,6 +909,18 @@ class GameUtilitiesTest extends FunSpec {
       }
     }
 
+    describe("When moves in question involve the same faceValue with Wildcard/Normalcard") {
+      val move1 = Move(List(THREE_Spade(7), SEVEN_Diamond, SEVEN_Heart))
+      val move2 = Move(List(THREE_Heart(7), SEVEN_Club, SEVEN_Spade))
+
+      it("Should return false when the gameState has the NormalCard") {
+        assert(!GameUtilities.checkIfBetter(move1, move2))
+      }
+
+      it("Should return true when the gameState has the WildCard") {
+        assert(GameUtilities.checkIfBetter(move2, move1))
+      }
+    }
   }
 
   describe("tests for cardOrderValue()") {

--- a/src/test/scala/GameUtilitiesTest.scala
+++ b/src/test/scala/GameUtilitiesTest.scala
@@ -1323,5 +1323,41 @@ class GameUtilitiesTest extends FunSpec {
     }
   }
 
+  describe("tests for getWildCardListFromIntermediateList") {
+    val intermediateList = List(
+      List(FOUR_Diamond, FOUR_Spade),
+      List(NINE_Spade),
+      List(JACK_Diamond, JACK_Heart, JACK_Spade),
+      List(ACE_Diamond, ACE_Club, ACE_Heart, ACE_Spade)
+    )
+    describe("When no wildcards are present in intermediate list") {
+      it("returns an empty list") {
+        assert(GameUtilities.getWildCardListFromIntermediateList(intermediateList) == List.empty)
+      }
+    }
+
+    describe("When wildcards are present in intermediate list") {
+      it("Should return a list of size 1 when number of wildcards is 1") {
+        val oneWildCardList = List(THREE_Diamond)
+        assert(GameUtilities.getWildCardListFromIntermediateList(intermediateList :+ oneWildCardList) == oneWildCardList)
+      }
+
+      it("Should return a list of size 2 when number of wildcards is 2") {
+        val oneWildCardList = List(THREE_Diamond, THREE_Club)
+        assert(GameUtilities.getWildCardListFromIntermediateList(intermediateList :+ oneWildCardList) == oneWildCardList)
+      }
+
+      it("Should return a list of size 3 when number of wildcards is 3") {
+        val oneWildCardList = List(THREE_Diamond, THREE_Club, THREE_Heart)
+        assert(GameUtilities.getWildCardListFromIntermediateList(intermediateList :+ oneWildCardList) == oneWildCardList)
+      }
+
+      it("Should return a list of size 4 when number of wildcards is 4") {
+        val oneWildCardList = List(THREE_Diamond,  THREE_Club, THREE_Heart, THREE_Spade)
+        assert(GameUtilities.getWildCardListFromIntermediateList(intermediateList :+ oneWildCardList) == oneWildCardList)
+      }
+    }
+
+  }
 
 }

--- a/src/test/scala/GameUtilitiesTest.scala
+++ b/src/test/scala/GameUtilitiesTest.scala
@@ -4,6 +4,7 @@ import utils.Consants
 
 import scala.util.Random
 import game.FaceValue._
+import game.GameUtilities.IllegalMoveSuppliedException
 import game.Suits._
 import player.Player
 import utils.Consants._
@@ -1371,11 +1372,72 @@ class GameUtilitiesTest extends FunSpec {
 
   }
 
-  describe("tests for getNewHand()") {
-
-  }
-
   describe("tests for addThreesToMoves()") {
+    val allMoves = Moves(List(
+      Move(List(SIX_Club, SIX_Diamond)),
+      Move(List(SEVEN_Heart)),
+      Move(List(KING_Heart, KING_Diamond, KING_Club)),
+      Move(List(TWO_Spade)), Move(List(Joker))))
+
+    describe("When suppliedMoves has a wildcard in it") {
+      it("Throws an exception") {
+        val moves = Moves(List(
+          Move(List(SIX_Club)),
+          Move(List(KING_Club, KING_Diamond)),
+          Move(List(THREE_Spade(9), NINE_Spade, NINE_Heart))
+        ))
+        assertThrows[IllegalMoveSuppliedException](GameUtilities.addThreesToMoves(moves, List(THREE_Spade)))
+      }
+    }
+
+    describe("When listOfThrees is empty") {
+      it("Should return allMoves without any changes") {
+        assert(GameUtilities.addThreesToMoves(allMoves, List.empty) == allMoves)
+      }
+    }
+
+    describe("When listOfThrees is nonEmpty") {
+
+      describe("When listOfThrees is of size 1") {
+        it("Should return result as expected") {
+          val listOfThrees = List(THREE_Diamond)
+          val expectedResult = Moves(allMoves.moves.slice(0, 3) ++ List(
+            Move(List(THREE_Diamond(6), SIX_Club, SIX_Diamond)),
+            Move(List(THREE_Diamond(7), SEVEN_Heart)),
+            Move(List(THREE_Diamond(13), KING_Heart, KING_Diamond, KING_Club)),
+            Move(List(THREE_Diamond(14))),
+            Move(List(TWO_Spade)), Move(List(Joker))))
+          println(expectedResult)
+          assert(GameUtilities.addThreesToMoves(allMoves, listOfThrees) == expectedResult)
+        }
+      }
+
+      describe("When listOfThrees is of size 2") {
+        it("Should return result as expected") {
+          val listOfThrees = List(THREE_Heart, THREE_Spade)
+          val expectedResult = Moves(allMoves.moves.slice(0, 3) ++ List(
+          Move(List(THREE_Heart(6), SIX_Club, SIX_Diamond)),
+          Move(List(THREE_Heart(7), SEVEN_Heart)),
+          Move(List(THREE_Heart(13), KING_Heart, KING_Diamond, KING_Club)),
+
+          Move(List(THREE_Spade(6), SIX_Club, SIX_Diamond)),
+          Move(List(THREE_Spade(7), SEVEN_Heart)),
+          Move(List(THREE_Spade(13), KING_Heart, KING_Diamond, KING_Club)),
+
+          Move(List(THREE_Heart(6), THREE_Spade(6), SIX_Club, SIX_Diamond)),
+          Move(List(THREE_Heart(7), THREE_Spade(7), SEVEN_Heart)),
+          Move(List(THREE_Heart(13), THREE_Spade(13),  KING_Heart, KING_Diamond, KING_Club)),
+
+          Move(List(THREE_Heart(14))),
+          Move(List(THREE_Spade(14))),
+          Move(List(THREE_Heart(14), THREE_Spade(14))),
+
+          Move(List(TWO_Spade)), Move(List(Joker))))
+          assert(GameUtilities.addThreesToMoves(allMoves, listOfThrees) == expectedResult)
+        }
+      }
+
+    }
 
   }
 

--- a/src/test/scala/GameUtilitiesTest.scala
+++ b/src/test/scala/GameUtilitiesTest.scala
@@ -1102,7 +1102,7 @@ class GameUtilitiesTest extends FunSpec {
     }
   }
 
-  describe("tests for filterOnlyNormalCardMoves") {
+  describe("tests for filterNonSpecialCardMoves()") {
 
     val listOfSpecialMoves = List(
       Move(List(SpecialCard(TWO, Diamond))),
@@ -1114,13 +1114,24 @@ class GameUtilitiesTest extends FunSpec {
       Move(List(NormalCard(NINE, Diamond), NormalCard(NINE, Club))),
       Move(List(NormalCard(JACK, Diamond), NormalCard(JACK, Club), NormalCard(JACK, Heart))),
       Move(List(NormalCard(ACE, Diamond), NormalCard(ACE, Club), NormalCard(ACE, Heart), NormalCard(ACE, Spade))))
+    val listOfWilcardMoves = List(
+      Move(List(THREE_Spade(7), SEVEN_Club)),
+      Move(List(THREE_Diamond(9), THREE_Spade(9), NINE_Spade))
+    )
     val validSpecialMoves = Moves(listOfSpecialMoves)
     val validNormalMoves = Moves(listOfNormalMoves)
+    val validWildCardMoves = Moves(listOfWilcardMoves)
+    val validNormalWildcardMoves = Moves(listOfWilcardMoves ++ listOfNormalMoves)
 
     describe("When validMoves comprise only of NormalCard moves") {
-
       it("Should return the validMoves itself") {
         assert(GameUtilities.filterNonSpecialCardMoves(validNormalMoves) == validNormalMoves)
+      }
+    }
+
+    describe("When validMoves comprise only of WildCard moves") {
+      it("Should return the validMoves itself") {
+        assert(GameUtilities.filterNonSpecialCardMoves(validWildCardMoves) == validWildCardMoves)
       }
     }
 
@@ -1133,6 +1144,18 @@ class GameUtilitiesTest extends FunSpec {
     describe("When validMoves comprise of both specialCard moves and NormalCard moves"){
       it("Should return list containing only NormalCard moves") {
         assert(GameUtilities.filterNonSpecialCardMoves(Moves(listOfSpecialMoves ++ listOfNormalMoves)) == validNormalMoves)
+      }
+    }
+
+    describe("When validMoves comprise of both NormalCard and WildCard moves") {
+      it("Should return list containing everything") {
+        assert(GameUtilities.filterNonSpecialCardMoves(Moves(listOfWilcardMoves ++ listOfNormalMoves)) == validNormalWildcardMoves)
+      }
+    }
+
+    describe("When validMoves comprise of both SpecialCard and WildCard moves") {
+      it("Should return list containing only wilcardMoves") {
+        assert(GameUtilities.filterNonSpecialCardMoves(Moves(listOfWilcardMoves ++ listOfSpecialMoves)) == validWildCardMoves)
       }
     }
   }
@@ -1271,5 +1294,7 @@ class GameUtilitiesTest extends FunSpec {
       assert(GameUtilities.getCardAssumedByWildCard(THREE_Spade(14)) == ACE_Spade)
     }
   }
+
+
 
 }

--- a/src/test/scala/GameUtilitiesTest.scala
+++ b/src/test/scala/GameUtilitiesTest.scala
@@ -1296,5 +1296,32 @@ class GameUtilitiesTest extends FunSpec {
   }
 
 
+  describe(" tests for getNumberOfWildCardsInMove()"){
+    it("Should return 0") {
+      val move = Move(List(ACE_Diamond, ACE_Club, ACE_Heart, ACE_Spade))
+      assert(GameUtilities.getNumberOfWildCardsInMove(move) == 0)
+    }
+
+    it("Should return 1") {
+      val move = Move(List(THREE_Diamond(14), ACE_Club, ACE_Heart, ACE_Spade))
+      assert(GameUtilities.getNumberOfWildCardsInMove(move) == 1)
+    }
+
+    it("Should return 2") {
+      val move = Move(List(THREE_Diamond(14), THREE_Club(14), ACE_Heart, ACE_Spade))
+      assert(GameUtilities.getNumberOfWildCardsInMove(move) == 2)
+    }
+
+    it("Should return 3") {
+      val move = Move(List(THREE_Diamond(14), THREE_Club(14), THREE_Heart(14), ACE_Spade))
+      assert(GameUtilities.getNumberOfWildCardsInMove(move) == 3)
+    }
+
+    it("Should return 4") {
+      val move = Move(List(THREE_Diamond(14), THREE_Club(14), THREE_Heart(14), THREE_Spade(14)))
+      assert(GameUtilities.getNumberOfWildCardsInMove(move) == 4)
+    }
+  }
+
 
 }

--- a/src/test/scala/GameUtilitiesTest.scala
+++ b/src/test/scala/GameUtilitiesTest.scala
@@ -245,7 +245,7 @@ class GameUtilitiesTest extends FunSpec {
     describe("When the hand is comprised of all possible cards") {
       it("Should return 13 sets of four cards of each suit and 1 set of two Jokers"){
         val expectedResult = List(
-          List(NormalCard(THREE, Diamond), NormalCard(THREE, Club), NormalCard(THREE, Heart), NormalCard(THREE, Spade)),
+          List(WildCard(THREE, Diamond), WildCard(THREE, Club), WildCard(THREE, Heart), WildCard(THREE, Spade)),
           List(NormalCard(FOUR, Diamond), NormalCard(FOUR, Club), NormalCard(FOUR, Heart), NormalCard(FOUR, Spade)),
           List(NormalCard(FIVE, Diamond), NormalCard(FIVE, Club), NormalCard(FIVE, Heart), NormalCard(FIVE, Spade)),
           List(NormalCard(SIX, Diamond), NormalCard(SIX, Club), NormalCard(SIX, Heart), NormalCard(SIX, Spade)),
@@ -967,7 +967,7 @@ class GameUtilitiesTest extends FunSpec {
     describe("When moves involving all types of cards are available") {
       it("Should return false") {
         val validMoves = Moves(List(
-          Move(List(NormalCard(THREE, Diamond))),
+          Move(List(WildCard(THREE, Diamond))),
           Move(List(NormalCard(SEVEN, Club))),
           Move(List(NormalCard(NINE, Heart))),
           Move(List(NormalCard(SIX, Diamond), NormalCard(SIX, Club))),

--- a/src/test/scala/PlayerTest.scala
+++ b/src/test/scala/PlayerTest.scala
@@ -17,50 +17,6 @@ class PlayerTest extends FunSpec{
     // No tests for playNextMove yet, individual methods are tested however
     // Possibly try and verify object method calls happened for unit testing
 
-    describe("Tests for getNewHand()") {
-      val currentHand = Hand(List(
-        NormalCard(SIX, Diamond),
-        NormalCard(SIX, Heart),
-        NormalCard(EIGHT, Club),
-        NormalCard(TEN, Heart),
-        NormalCard(ACE, Diamond),
-        NormalCard(ACE, Heart),
-        SpecialCard(TWO, Diamond),
-        Joker,
-      ))
-      val player = Player("Test", currentHand)
-      describe("When the movePlayed is none"){
-        it("Should return the same hand") {
-          assert(player.getNewHand(player.hand, None) == currentHand)
-        }
-      }
-
-      describe("When the movePlayed does not involve a hand"){
-        it("Should return the same hand") {
-          assert(player.getNewHand(player.hand, Some(Move(List(NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Spade)))))
-                 == currentHand)
-        }
-      }
-
-      describe("When the movePlayed involves a card in the hand"){
-        describe("When the move played is a normalCard") {
-          it("Should return the hand minus the played cards") {
-            assert(player.getNewHand(player.hand, Some(Move(List(NormalCard(ACE, Diamond), NormalCard(ACE, Heart)))))
-                  == Hand(currentHand.listOfCards.slice(0,4) ++ currentHand.listOfCards.slice(6, 8)))
-          }
-        }
-      }
-
-      describe("When the move played is a specialCard") {
-        it("Should return the hand minus the played cards") {
-          assert(player.getNewHand(player.hand, Some(Move(List(SpecialCard(TWO, Diamond)))))
-                  == Hand(currentHand.listOfCards.slice(0,6) ++ currentHand.listOfCards.slice(7, 8)))
-          assert(player.getNewHand(player.hand, Some(Move(List(Joker))))
-                  == Hand(currentHand.listOfCards.slice(0,7)))
-        }
-      }
-    }
-
   }
 
 

--- a/src/test/scala/PlayerTest.scala
+++ b/src/test/scala/PlayerTest.scala
@@ -33,6 +33,18 @@ class PlayerTest extends FunSpec{
       }
     }
 
+    describe("Tests for applyWildCardPenaltyModifier()") {
+      it("Should get the modifier value based on the function (1 /(1 + e^[-((0.5d * sizeOfHand) - 4)]))") {
+        assert(PlayerIndicators.applyWildCardPenaltyModifer(0) === 0.0179)
+        assert(PlayerIndicators.applyWildCardPenaltyModifer(1) === 0.0293)
+        assert(PlayerIndicators.applyWildCardPenaltyModifer(5) === 0.1824)
+        assert(PlayerIndicators.applyWildCardPenaltyModifer(10) === 0.7310)
+        assert(PlayerIndicators.applyWildCardPenaltyModifer(15) === 0.9706)
+        assert(PlayerIndicators.applyWildCardPenaltyModifer(20) === 0.9975)
+        assert(PlayerIndicators.applyWildCardPenaltyModifer(27) === 0.9999)
+      }
+    }
+
     // TODO - update these tests for Wildcards
     describe("Tests for getListSetSizeForCard()") {
 

--- a/src/test/scala/PlayerTest.scala
+++ b/src/test/scala/PlayerTest.scala
@@ -33,6 +33,7 @@ class PlayerTest extends FunSpec{
       }
     }
 
+    // TODO - update these tests for Wildcards
     describe("Tests for getListSetSizeForCard()") {
 
       describe("When validMove size is 1") {

--- a/src/test/scala/PlayerTest.scala
+++ b/src/test/scala/PlayerTest.scala
@@ -1,8 +1,7 @@
-import game.FaceValue._
-import game.Suits._
 import game.{Hand, Joker, Move, NormalCard, SpecialCard}
 import org.scalatest.FunSpec
 import player.{Player, PlayerIndicators}
+import utils.Consants._
 
 import org.scalactic.{Equality, TolerantNumerics}
 
@@ -49,11 +48,11 @@ class PlayerTest extends FunSpec{
     describe("Tests for getListSetSizeForCard()") {
 
       describe("When validMove size is 1") {
-        val validMove = Move(List(NormalCard(SEVEN, Spade)))
+        val validMove = Move(List(SEVEN_Spade))
 
         describe("When it is only a single card") {
           it("Should return 1") {
-            val hand = Hand(List(NormalCard(SEVEN, Diamond)))
+            val hand = Hand(List(SEVEN_Diamond))
             val playerIndicators = PlayerIndicators(hand)
             assert(playerIndicators.getListSetSizeForCard(validMove) == 1)
           }
@@ -61,7 +60,7 @@ class PlayerTest extends FunSpec{
 
         describe("When it is part of a double") {
           it("Should return 2") {
-            val hand = Hand(List(NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club)))
+            val hand = Hand(List(SEVEN_Diamond, SEVEN_Club))
             val playerIndicators = PlayerIndicators(hand)
             assert(playerIndicators.getListSetSizeForCard(validMove) == 2)
           }
@@ -69,7 +68,7 @@ class PlayerTest extends FunSpec{
 
         describe("When it is part of a triple") {
           it("Should return 3") {
-            val hand = Hand(List(NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club), NormalCard(SEVEN, Heart)))
+            val hand = Hand(List(SEVEN_Diamond, SEVEN_Club, SEVEN_Heart))
             val playerIndicators = PlayerIndicators(hand)
             assert(playerIndicators.getListSetSizeForCard(validMove) == 3)
           }
@@ -77,7 +76,7 @@ class PlayerTest extends FunSpec{
 
         describe("When it is part of a quad") {
           it("Should return 4") {
-            val hand = Hand(List(NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club), NormalCard(SEVEN, Heart), NormalCard(SEVEN, Spade)))
+            val hand = Hand(List(SEVEN_Diamond, SEVEN_Club, SEVEN_Heart, SEVEN_Spade))
             val playerIndicators = PlayerIndicators(hand)
             assert(playerIndicators.getListSetSizeForCard(validMove) == 4)
           }
@@ -85,11 +84,11 @@ class PlayerTest extends FunSpec{
       }
 
       describe("When validMove size is 2") {
-        val validMove = Move(List(NormalCard(SEVEN, Heart), NormalCard(SEVEN, Spade)))
+        val validMove = Move(List(SEVEN_Heart, SEVEN_Spade))
 
         describe("When it is part of a double") {
           it("Should return 2") {
-            val hand = Hand(List(NormalCard(SEVEN, Heart), NormalCard(SEVEN, Spade)))
+            val hand = Hand(List(SEVEN_Heart, SEVEN_Spade))
             val playerIndicators = PlayerIndicators(hand)
             assert(playerIndicators.getListSetSizeForCard(validMove) == 2)
           }
@@ -97,7 +96,7 @@ class PlayerTest extends FunSpec{
 
         describe("When it is part of a triple") {
           it("Should return 3") {
-            val hand = Hand(List(NormalCard(SEVEN, Club), NormalCard(SEVEN, Heart), NormalCard(SEVEN, Spade)))
+            val hand = Hand(List(SEVEN_Club, SEVEN_Heart, SEVEN_Spade))
             val playerIndicators = PlayerIndicators(hand)
             assert(playerIndicators.getListSetSizeForCard(validMove) == 3)
           }
@@ -105,7 +104,7 @@ class PlayerTest extends FunSpec{
 
         describe("When it is part of a quad") {
           it("Should return 4") {
-            val hand = Hand(List(NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club), NormalCard(SEVEN, Heart), NormalCard(SEVEN, Spade)))
+            val hand = Hand(List(SEVEN_Diamond, SEVEN_Club, SEVEN_Heart, SEVEN_Spade))
             val playerIndicators = PlayerIndicators(hand)
             assert(playerIndicators.getListSetSizeForCard(validMove) == 4)
           }
@@ -113,11 +112,11 @@ class PlayerTest extends FunSpec{
       }
 
       describe("When validMove size is 3") {
-        val validMove = Move(List(NormalCard(SEVEN, Club), NormalCard(SEVEN, Heart), NormalCard(SEVEN, Spade)))
+        val validMove = Move(List(SEVEN_Club, SEVEN_Heart, SEVEN_Spade))
 
         describe("When it is part of a triple") {
           it("Should return 3") {
-            val hand = Hand(List(NormalCard(SEVEN, Club), NormalCard(SEVEN, Heart), NormalCard(SEVEN, Spade)))
+            val hand = Hand(List(SEVEN_Club, SEVEN_Heart, SEVEN_Spade))
             val playerIndicators = PlayerIndicators(hand)
             assert(playerIndicators.getListSetSizeForCard(validMove) == 3)
           }
@@ -125,7 +124,7 @@ class PlayerTest extends FunSpec{
 
         describe("When it is part of a quad") {
           it("Should return 4") {
-            val hand = Hand(List(NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club), NormalCard(SEVEN, Heart), NormalCard(SEVEN, Spade)))
+            val hand = Hand(List(SEVEN_Diamond, SEVEN_Club, SEVEN_Heart, SEVEN_Spade))
             val playerIndicators = PlayerIndicators(hand)
             assert(playerIndicators.getListSetSizeForCard(validMove) == 4)
           }
@@ -133,15 +132,79 @@ class PlayerTest extends FunSpec{
       }
 
       describe("When validMove size is 4") {
-        val validMove = Move(List(NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club), NormalCard(SEVEN, Heart), NormalCard(SEVEN, Spade)))
+        val validMove = Move(List(SEVEN_Diamond, SEVEN_Club, SEVEN_Heart, SEVEN_Spade))
 
         describe("When it is part of a quad") {
           it("Should return 4") {
-            val hand = Hand(List(NormalCard(SEVEN, Diamond), NormalCard(SEVEN, Club), NormalCard(SEVEN, Heart), NormalCard(SEVEN, Spade)))
+            val hand = Hand(List(SEVEN_Diamond, SEVEN_Club, SEVEN_Heart, SEVEN_Spade))
             val playerIndicators = PlayerIndicators(hand)
             assert(playerIndicators.getListSetSizeForCard(validMove) == 4)
           }
         }
+      }
+
+      describe("When validMove has wildcards in it") {
+
+        describe("When it is comprised purely of wildcards") {
+          it("Should return move parity when size is 2") {
+            val validMove = Move(List(THREE_Diamond(14), THREE_Spade(14)))
+            val hand = Hand(List(SEVEN_Diamond, SEVEN_Club, SEVEN_Heart, SEVEN_Spade))
+            val playerIndicators = PlayerIndicators(hand)
+            assert(playerIndicators.getListSetSizeForCard(validMove) == validMove.parity)
+          }
+
+          it("Should return move parity when size is 3") {
+            val validMove = Move(List(THREE_Diamond(14), THREE_Club(14), THREE_Spade(14)))
+            val hand = Hand(List(SEVEN_Diamond, SEVEN_Club, SEVEN_Heart, SEVEN_Spade))
+            val playerIndicators = PlayerIndicators(hand)
+            assert(playerIndicators.getListSetSizeForCard(validMove) == validMove.parity)
+          }
+
+          it("Should return move parity when size is 4") {
+            val validMove = Move(List(THREE_Diamond(14), THREE_Club(14), THREE_Heart(14), THREE_Spade(14)))
+            val hand = Hand(List(SEVEN_Diamond, SEVEN_Club, SEVEN_Heart, SEVEN_Spade))
+            val playerIndicators = PlayerIndicators(hand)
+            assert(playerIndicators.getListSetSizeForCard(validMove) == validMove.parity)
+          }
+        }
+
+        describe("When move is comprised of wildcards plus normalCards") {
+          val validMove = Move(List(THREE_Diamond(12), THREE_Club(12), QUEEN_Heart))
+
+          describe("When it is the only card in Hand") {
+            it("Should return 1") {
+              val hand = Hand(List(JACK_Diamond, QUEEN_Heart, KING_Heart))
+              val playerIndicators = PlayerIndicators(hand)
+              assert(playerIndicators.getListSetSizeForCard(validMove) == 1)
+            }
+          }
+
+          describe("When it is part of a double") {
+            it("Should return 1") {
+              val hand = Hand(List(JACK_Diamond, QUEEN_Heart, QUEEN_Spade, KING_Heart))
+              val playerIndicators = PlayerIndicators(hand)
+              assert(playerIndicators.getListSetSizeForCard(validMove) == 2)
+            }
+          }
+
+          describe("When it is part of a triple") {
+            it("Should return 1") {
+              val hand = Hand(List(JACK_Diamond, QUEEN_Diamond, QUEEN_Club, QUEEN_Heart, KING_Heart))
+              val playerIndicators = PlayerIndicators(hand)
+              assert(playerIndicators.getListSetSizeForCard(validMove) == 3)
+            }
+          }
+
+          describe("When it is part of a quad") {
+            it("Should return 1") {
+              val hand = Hand(List(JACK_Diamond, QUEEN_Diamond, QUEEN_Club, QUEEN_Heart, QUEEN_Spade, KING_Heart))
+              val playerIndicators = PlayerIndicators(hand)
+              assert(playerIndicators.getListSetSizeForCard(validMove) == 4)
+            }
+          }
+
+        }
+
       }
     }
   }

--- a/src/test/scala/RoundTest.scala
+++ b/src/test/scala/RoundTest.scala
@@ -173,4 +173,12 @@ class RoundTest extends FunSpec {
 
   }
 
+  describe("tests for getIndexOfNextPlayer()") {
+
+  }
+
+  describe("tests for updatedRoundPassStatus") {
+
+  }
+
 }

--- a/src/test/scala/RoundTest.scala
+++ b/src/test/scala/RoundTest.scala
@@ -174,10 +174,124 @@ class RoundTest extends FunSpec {
   }
 
   describe("tests for getIndexOfNextPlayer()") {
+    Round.initialListOfPlayerNames = List("p1", "p2", "p3", "p4")
+    val players = GameUtilities.generatePlayersAndDealHands(Round.initialListOfPlayerNames)
+
+    describe("When the player who's turn it is exists still") {
+
+      it("Should return their index when it is at the start of the list") {
+        val round = Round(Move(List.empty), "p1", 4, 3, players, Round.getNoPassList(4))
+        assert(round.getIndexOfNextPlayer == 1)
+      }
+
+      it("Should return index when it is at the end of the list") {
+        val round = Round(Move(List.empty), "p4", 4, 3, players, Round.getNoPassList(4))
+        assert(round.getIndexOfNextPlayer == 0)
+      }
+
+      it("Should return index when it is in the middle of the list") {
+        val round = Round(Move(List.empty), "p2", 4, 3, players, Round.getNoPassList(4))
+        assert(round.getIndexOfNextPlayer == 2)
+      }
+
+    }
+
+    describe("When the player who's turn it is does not exist anymore") {
+
+      describe("When only one player has completed the game") {
+
+        describe("When the player who completed started the game") {
+          it("Should return index 0") {
+            val round = Round(Move(List.empty), "p1", 4, 3, players.drop(1), Round.getNoPassList(4))
+            assert(round.getIndexOfNextPlayer == 0)
+          }
+        }
+
+        describe("When the player who completed went last in the first round") {
+          it("Should return index 0") {
+            val round = Round(Move(List.empty), "p4", 4, 3, players.take(3), Round.getNoPassList(4))
+            assert(round.getIndexOfNextPlayer == 0)
+          }
+        }
+
+        describe("When the player who completed went 2nd in the first round") {
+          it("Should return index 0") {
+            val round = Round(Move(List.empty), "p2", 4, 3, players.slice(0,1) ++ players.slice(2, 4), Round.getNoPassList(4))
+            assert(round.getIndexOfNextPlayer == 1)
+          }
+        }
+
+      }
+
+      describe("When two players have completed the game") {
+        describe("When the player who completed most recently is p2 - after p3") {
+          it("Should return index 1 pertaining to p4") {
+            val round = Round(Move(List.empty), "p2", 4, 3, players.slice(0,1) ++ players.slice(3, 4), Round.getNoPassList(4))
+            assert(round.getIndexOfNextPlayer == 1)
+          }
+        }
+
+        describe("When the player who completed most recently is p4 - after p3") {
+          it("Should return index 0 pertaining to p1") {
+            val round = Round(Move(List.empty), "p4", 4, 3, players.slice(0,2), Round.getNoPassList(4))
+            assert(round.getIndexOfNextPlayer == 0)
+          }
+        }
+
+        describe("When the player who completed most recently is p1 - after p3") {
+          it("Should return index 0 pertaining to p2") {
+            val round = Round(Move(List.empty), "p1", 4, 3, players.slice(1,2) ++ players.slice(3,4), Round.getNoPassList(4))
+            assert(round.getIndexOfNextPlayer == 0)
+          }
+        }
+
+        describe("When the player who completed most recently is p3 - after p2") {
+          it("Should return index 1 pertaining to p4") {
+            val round = Round(Move(List.empty), "p1", 4, 3, players.slice(0,1) ++ players.slice(3,4), Round.getNoPassList(4))
+            assert(round.getIndexOfNextPlayer == 1)
+          }
+        }
+      }
+
+    }
 
   }
 
   describe("tests for updatedRoundPassStatus") {
+    Round.initialListOfPlayerNames = List("p1", "p2", "p3", "p4")
+    val players = GameUtilities.generatePlayersAndDealHands(Round.initialListOfPlayerNames)
+
+    describe("When index is at the beginning") {
+      it("Should return expected value") {
+        val round = Round(Move(List.empty), "p2", 4, 3, players, List(true, false, true, false))
+        val expected = List(false, true, false)
+        assert(round.updatedRoundPassStatus(0) == expected)
+      }
+    }
+
+    describe("When indexToRemove is at the end") {
+      it("Should return expected value") {
+        val round = Round(Move(List.empty), "p2", 4, 3, players, List(true, false, true, false))
+        val expected = List(true, false, true)
+        assert(round.updatedRoundPassStatus(3) == expected)
+      }
+    }
+
+    describe("When indexToRemove is in the middle") {
+      it("Should return expected value") {
+        val round = Round(Move(List.empty), "p2", 4, 3, players, List(true, false, true, false))
+        val expected = List(true, true, false)
+        assert(round.updatedRoundPassStatus(1) == expected)
+      }
+    }
+
+    describe("When indexToRemove is greater than size of roundPassStatus") {
+      it("Should return same value") {
+        val round = Round(Move(List.empty), "p2", 4, 3, players, List(true, false, true, false))
+        val expected = List(true, false, true, false)
+        assertThrows[IndexOutOfBoundsException](round.updatedRoundPassStatus(5) == expected)
+      }
+    }
 
   }
 


### PR DESCRIPTION
Threes can be played as wildcards
Moves involving threes are penalized
The penalty is based on the value of card assumed, parity of move and number of threes used
The penalty diminishes as hand size decreases
WildCards played without a NormalCard will either assume the value of gameState resulting in a suit burn, OR assume the value of and Ace of the same suit
WildCards can be used to burn cards
The real NormalCard can burn a WildCard